### PR TITLE
kube-hunter: fix `env` path in shebang

### DIFF
--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 from __future__ import print_function
 
 import argparse


### PR DESCRIPTION
Currently, `./kube-hunter.py` results in:

```
-bash: ./kube-hunter.py: /bin/env: bad interpreter: No such file or directory
```