### PR TITLE
Move azure component to types

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -72,6 +72,9 @@ _The file's (module's) content is imported automatically"_
 The second step is to determine what events your Hunter will subscribe to, and from where you can get them.  
 `Convention:` Events should be declared in their corresponding module. for example, a KubeDashboardEvent event is declared in the dashboard discovery module.  
      
+ `Notice:` An hunter located under the `disovery` folder should not import any modules located under the `hunting` folder 
+in order to prevent circular dependency bug.
+
 Following the above example, let's figure out the imports:  
 ```python  
 from ...core.types import Hunter  
@@ -114,7 +117,7 @@ relative import: `...core.types`
   
   
 ## Creating Events  
-As discussed above, we know there are alot of different types of events that can be created. but at the end, they all need to inherit from the base class `Event`  
+As discussed above, we know there are a lot of different types of events that can be created. but at the end, they all need to inherit from the base class `Event`  
 lets see some examples of creating different types of events:  
 ### Vulnerability  
 ```python  

--- a/src/README.md
+++ b/src/README.md
@@ -72,7 +72,7 @@ _The file's (module's) content is imported automatically"_
 The second step is to determine what events your Hunter will subscribe to, and from where you can get them.  
 `Convention:` Events should be declared in their corresponding module. for example, a KubeDashboardEvent event is declared in the dashboard discovery module.  
      
- `Notice:` An hunter located under the `disovery` folder should not import any modules located under the `hunting` folder 
+ `Note:` An hunter located under the `discovery` folder should not import any modules located under the `hunting` folder 
 in order to prevent circular dependency bug.
 
 Following the above example, let's figure out the imports:  

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -17,6 +17,9 @@ class Kubelet(KubernetesCluster):
     """The kubelet is the primary "node agent" that runs on each node"""
     name = "Kubelet"
 
+class Azure(KubernetesCluster):
+    """Azure Cluster"""
+    name = "Azure"
 
 """ Categories """
 class InformationDisclosure(object):

--- a/src/modules/discovery/hosts.py
+++ b/src/modules/discovery/hosts.py
@@ -13,8 +13,7 @@ from netifaces import AF_INET, ifaddresses, interfaces
 
 from ...core.events import handler
 from ...core.events.types import Event, NewHostEvent, Vulnerability
-from ...core.types import Hunter, InformationDisclosure
-from ..hunting.aks import Azure
+from ...core.types import Hunter, InformationDisclosure, Azure
 
 
 class AzureMetadataApi(Vulnerability, Event):

--- a/src/modules/hunting/aks.py
+++ b/src/modules/hunting/aks.py
@@ -8,10 +8,7 @@ from kubelet import ExposedRunHandler
 from ...core.events import handler
 from ...core.events.types import Event, Vulnerability
 from ...core.types import Hunter, ActiveHunter, KubernetesCluster, IdentityTheft
-   
-class Azure(KubernetesCluster):
-    """Azure Cluster"""
-    name = "Azure"
+
 
 class AzureSpnExposure(Vulnerability, Event):
     """The SPN is exposed, potentially allowing an attacker to gain access to the Azure subscription"""

--- a/src/modules/hunting/aks.py
+++ b/src/modules/hunting/aks.py
@@ -7,7 +7,7 @@ from kubelet import ExposedRunHandler
 
 from ...core.events import handler
 from ...core.events.types import Event, Vulnerability
-from ...core.types import Hunter, ActiveHunter, KubernetesCluster, IdentityTheft
+from ...core.types import Hunter, ActiveHunter, IdentityTheft, Azure
 
 
 class AzureSpnExposure(Vulnerability, Event):


### PR DESCRIPTION
I believe importing a hunting module from a discovery file is a bad practice.

I Had to to it so we won't have circular dependency bug when importing the RunningAsPodEvent event.
(discovery **was** importing from hunting, hunting was importing from discovery ).

I have rebased using that branch in the access secrets hunter so I can subscribe to RunningAsPodEvent
