### PR TITLE
CVE-2018-10020105 reported too often

### DIFF
--- a/src/modules/hunting/CVE_2018_1002105.py
+++ b/src/modules/hunting/CVE_2018_1002105.py
@@ -65,7 +65,7 @@ class IsVulnerableToCVEAttack(Hunter):
             return False
 
     def execute(self):
-        self.get_service_account_token():  # From within a Pod we may have extra credentials
+        self.get_service_account_token()  # From within a Pod we may have extra credentials
         if self.access_api_server_version_end_point():
             self.publish_event(ServerApiVersionEndPointAccess(self.api_server_evidence))
 

--- a/src/modules/hunting/CVE_2018_1002105.py
+++ b/src/modules/hunting/CVE_2018_1002105.py
@@ -10,20 +10,16 @@ from ...core.types import Hunter, ActiveHunter, KubernetesCluster, RemoteCodeExe
 
 """ Vulnerabilities """
 class ServerApiVersionEndPointAccess(Vulnerability, Event):
-    """ CVE-2018-1002105
-    Pod is vulnerable to critical CVE-2018-1002105
-"""
+    """ Node is vulnerable to critical CVE-2018-1002105 """
 
     def __init__(self, evidence):
-        Vulnerability.__init__(self, KubernetesCluster, name="Critical PrivilegedEscalation CVE", category=PrivilegeEscalation)
+        Vulnerability.__init__(self, KubernetesCluster, name="Critical Privilege Escalation CVE", category=PrivilegeEscalation)
         self.evidence = evidence
 
 # Passive Hunter
 @handler.subscribe(OpenPortEvent, predicate=lambda x: x.port == 443 or x.port == 6443)
 class IsVulnerableToCVEAttack(Hunter):
-    """ CVE-2018-1002105
-    Pod is vulnerable to critical CVE-2018-1002105
-    """
+    """ Node is running a Kubernetes version vulnerable to critical CVE-2018-1002105 """
 
     def __init__(self, event):
         self.event = event
@@ -69,9 +65,7 @@ class IsVulnerableToCVEAttack(Hunter):
             return False
 
     def execute(self):
-        if self.get_service_account_token():  # From within a Pod
-            if self.access_api_server_version_end_point():
-                self.publish_event(ServerApiVersionEndPointAccess(self.api_server_evidence))
-        else:
+        self.get_service_account_token():  # From within a Pod we may have extra credentials
+        if self.access_api_server_version_end_point():
             self.publish_event(ServerApiVersionEndPointAccess(self.api_server_evidence))
 


### PR DESCRIPTION
If we weren't able to get the service account token (which would always happen if we weren't running in a pod), we were just going ahead and reporting the vulnerability anyway