### PR TITLE
Make rebuilding kube-hunter image after code changes quick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ RUN apk add --update \
     wireshark
 
 RUN mkdir -p /kube-hunter 
+COPY ./requirements.txt /kube-hunter/.
+RUN pip install -r /kube-hunter/requirements.txt
+
 COPY . /kube-hunter
 WORKDIR /kube-hunter
-RUN pip install -r requirements.txt
 
 ENTRYPOINT ["python",  "kube-hunter.py"]


### PR DESCRIPTION
Somewhat dirty (perhaps there is a better multi-stage build solution). First copy requirements.txt only and install all dependencies. Then copy all kube-hunter new code. This way only latest layer changing on code changes and all previous can be brought from cache.