### PR TITLE
Add '--quick' option to kube-hunter command line arguments

### DIFF
--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -14,6 +14,7 @@ parser = argparse.ArgumentParser(description='Kube-Hunter - hunts for security w
 parser.add_argument('--list', action="store_true", help="displays all tests in kubehunter (add --active flag to see active tests)")
 parser.add_argument('--internal', action="store_true", help="set hunting of all internal network interfaces")
 parser.add_argument('--pod', action="store_true", help="set hunter as an insider pod")
+parser.add_argument('--quick', action="store_true", help="Prefer quick scan (subnet 24)")
 parser.add_argument('--cidr', type=str, help="set an ip range to scan, example: 192.168.0.0/16")
 parser.add_argument('--mapping', action="store_true", help="outputs only a mapping of the cluster's nodes")
 parser.add_argument('--remote', nargs='+', metavar="HOST", default=list(), help="one or more remote ip/dns to hunt")


### PR DESCRIPTION
This was probably forgotten in some old commit, as it is used in azure_metadata_discovery function in discovery/hosts.py but was not implemented, causing from pod scanning in Azure  not to work (due to exception). 

Please note that if the instance's subnet (where pod runs) is wide (e.x. X,X,X,X/12) the '--quick' option must be used for scan to complete within reasonable time. 