### PR TITLE
Fix: the pod service account token vulnerability 'Location' is wrong

### DIFF
--- a/src/modules/hunting/apiserver.py
+++ b/src/modules/hunting/apiserver.py
@@ -19,15 +19,6 @@ class ServerApiAccess(Vulnerability, Event):
         self.evidence = evidence
 
 
-class ServiceAccountTokenAccess(Vulnerability, Event):
-    """ Accessing the pod service account token gives an attacker the option to use the server API """
-
-    def __init__(self, evidence):
-        Vulnerability.__init__(self, KubernetesCluster, name="Read access to pod's service account token",
-                               category=AccessRisk)
-        self.evidence = evidence
-
-
 class ListPodUnderDefaultNamespace(Vulnerability, Event):
     """ Accessing the pods list under default namespace might give an attacker valuable
      information to harm the cluster """
@@ -327,7 +318,6 @@ class AccessApiServerViaServiceAccountToken(Hunter):
     def execute(self):
 
         if self.get_service_account_token():
-            self.publish_event(ServiceAccountTokenAccess(self.service_account_token_evidence))
             if self.access_api_server():
                 self.publish_event(ServerApiAccess(self.api_server_evidence))
 

--- a/src/modules/hunting/secrets.py
+++ b/src/modules/hunting/secrets.py
@@ -11,6 +11,14 @@ from ...core.types import Hunter, KubernetesCluster, AccessRisk
 from ..discovery.hosts import RunningAsPodEvent
 
 """ Vulnerabilities """
+class ServiceAccountTokenAccess(Vulnerability, Event):
+    """ Accessing the pod service account token gives an attacker the option to use the server API """
+
+    def __init__(self, evidence):
+        Vulnerability.__init__(self, KubernetesCluster, name="Read access to pod's service account token",
+                               category=AccessRisk)
+        self.evidence = evidence
+
 class SecretsAccess(Vulnerability, Event):
     """ Accessing the pod's secrets within a compromised pod might disclose valuable data to a potential attacker"""
 
@@ -37,5 +45,7 @@ class AccessSecrets(Hunter):
         return True if (len(self.secrets_evidence) > 0) else False
 
     def execute(self):
+        if self.event.auth_token is not None:
+            self.publish_event(ServiceAccountTokenAccess(self.event.auth_token))
         if self.get_services():
             self.publish_event(SecretsAccess(self.secrets_evidence))


### PR DESCRIPTION
The vulnerability reported with location of API server. Moved the vulnerability discovery to 'secrets' hunter.

Before the fix:
```
+------------------+----------------------+----------------------+----------------------+----------------------+
| 10.240.0.15:443  | Access Risk          | Read access to pod's |  Accessing the pod   | eyJhbGciOiJSUzI1NiIs |
```

After the fix:

```
+------------------+----------------------+----------------------+----------------------+----------------------+
|                  | Access Risk               | Read access to pod's |  Accessing the pod   |  eyJhbGciOiJSUzI1NiIs 
```

Which similar to access to secrets vulnerability:
```
+------------------+----------------------+----------------------+----------------------+----------------------+
|                  | Access Risk          | Accessed to pod's    |  Accessing the pod's | ['/var/run/secrets/k |
```