### PR TITLE
add client ceritficate support

### DIFF
--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -21,6 +21,8 @@ parser.add_argument('--remote', nargs='+', metavar="HOST", default=list(), help=
 parser.add_argument('--active', action="store_true", help="enables active hunting")
 parser.add_argument('--log', type=str, metavar="LOGLEVEL", default='INFO', help="set log level, options are: debug, info, warn, none")
 parser.add_argument('--report', type=str, default='plain', help="set report type, options are: plain, yaml")
+parser.add_argument('--clientkey', type=str,help="path to a client certificate key to authenticate to Kubernetes")
+parser.add_argument('--clientcert', type=str,help="path to a client certificate cert to authenticate to Kubernetes")
 
 import plugins
 

--- a/src/core/util.py
+++ b/src/core/util.py
@@ -1,0 +1,12 @@
+import os
+
+from __main__ import config
+
+
+def get_client_cert():
+    if config.clientcert and config.clientkey:
+        return config.clientcert, config.clientkey
+    elif config.clientcert:
+        return config.clientcert
+    else:
+        return None

--- a/src/modules/discovery/apiserver.py
+++ b/src/modules/discovery/apiserver.py
@@ -1,6 +1,7 @@
 import requests
 import logging
 
+from ...core.util import get_client_cert
 from ...core.types import Hunter
 from ...core.events import handler
 from ...core.events.types import OpenPortEvent, Service, Event
@@ -27,7 +28,7 @@ class ApiServerDiscovery(Hunter):
 
     def execute(self):
         logging.debug("Attempting to discover an Api server")
-        main_request = requests.get("https://{}:{}".format(self.event.host, self.event.port), verify=False).text
+        main_request = requests.get("https://{}:{}".format(self.event.host, self.event.port), verify=False, cert=get_client_cert()).text
         if "code" in main_request:
             self.event.role = "Master"
         self.publish_event(ApiServer())

--- a/src/modules/discovery/proxy.py
+++ b/src/modules/discovery/proxy.py
@@ -1,6 +1,8 @@
 import logging
 import requests
 from collections import defaultdict
+
+from ...core.util import get_client_cert
 from ...core.types import Hunter
 
 from requests import get
@@ -26,10 +28,10 @@ class KubeProxy(Hunter):
     @property
     def accesible(self):
         logging.debug("Attempting to discover a proxy service")
-        r = requests.get("http://{host}:{port}/api/v1".format(host=self.host, port=self.port))
+        r = requests.get("http://{host}:{port}/api/v1".format(host=self.host, port=self.port), cert=get_client_cert())
         if r.status_code == 200 and "APIResourceList" in r.text:
             return True
 
     def execute(self):
         if self.accesible:
-            self.publish_event(KubeProxyEvent())        
+            self.publish_event(KubeProxyEvent())

--- a/src/modules/hunting/CVE_2018_1002105.py
+++ b/src/modules/hunting/CVE_2018_1002105.py
@@ -4,6 +4,7 @@ import requests
 import uuid
 import ast
 
+from ...core.util import get_client_cert
 from ...core.events import handler
 from ...core.events.types import Vulnerability, Event, OpenPortEvent
 from ...core.types import Hunter, ActiveHunter, KubernetesCluster, RemoteCodeExec, AccessRisk, InformationDisclosure, PrivilegeEscalation
@@ -34,7 +35,7 @@ class IsVulnerableToCVEAttack(Hunter):
         logging.debug('Passive Hunter is attempting to access the API server /version end point using the pod\'s service account token')
         try:
             res = requests.get("{path}/version".format(path=self.path),
-                               headers=self.headers, verify=False)
+                               headers=self.headers, verify=False, cert=get_client_cert())
             self.api_server_evidence = res.content
             resDict = ast.literal_eval(res.content)
             version = resDict["gitVersion"].split('.')
@@ -68,4 +69,3 @@ class IsVulnerableToCVEAttack(Hunter):
         self.get_service_account_token()  # From within a Pod we may have extra credentials
         if self.access_api_server_version_end_point():
             self.publish_event(ServerApiVersionEndPointAccess(self.api_server_evidence))
-


### PR DESCRIPTION
added new option to specify a client certificate to authenticate to the apiserver.

all `requests` invocations that are not used from within the pod have been adjusted