### PR TITLE
enable --cidr option when running as pod

### DIFF
--- a/src/modules/discovery/hosts.py
+++ b/src/modules/discovery/hosts.py
@@ -76,7 +76,15 @@ class FromPodHostDiscovery(Hunter):
     def execute(self):
         # Discover master API server from in-pod environment variable.
 
-        if self.is_azure_pod():
+        if config.cidr:
+            try:
+                ip, sn = config.cidr.split('/')
+            except ValueError as e:
+                logging.error("unable to parse cidr: {0}".format(e))
+                return
+            cloud = HostDiscoveryHelpers.get_cloud(ip)
+            subnets = [[ip, sn], ]
+        elif self.is_azure_pod():
             subnets, cloud =self.azure_metadata_discovery()
         else:
             subnets, cloud = self.traceroute_discovery()


### PR DESCRIPTION
this PR allows the use of the --cidr option together with the --pod option

in our setup the discovery fails because we don't have connectivity to the outside world
with this new option we can just manually specify which IP's we want to test