### PR TITLE
Fix tests

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -15,6 +15,8 @@ parser.add_argument('--report', type=str, default='plain', help="set report type
 
 config = parser.parse_args()
 
+import tests
+
 def main():
     exit(pytest.main(['.']))
 

--- a/tests/discovery/test_apiserver.py
+++ b/tests/discovery/test_apiserver.py
@@ -1,8 +1,8 @@
 import requests_mock
 
-from apiserver import ApiServer, ApiServerDiscovery
-from ...core.events.types import Event
-from ...core.events import handler
+from src.modules.discovery.apiserver import ApiServer, ApiServerDiscovery
+from src.core.events.types import Event
+from src.core.events import handler
 
 def test_ApiServer():
 

--- a/tests/discovery/test_hosts.py
+++ b/tests/discovery/test_hosts.py
@@ -2,9 +2,9 @@ import requests_mock
 import time
 from Queue import Empty
 
-from hosts import FromPodHostDiscovery, RunningAsPodEvent, HostScanEvent, AzureMetadataApi
-from ...core.events.types import Event, NewHostEvent
-from ...core.events import handler
+from src.modules.discovery.hosts import FromPodHostDiscovery, RunningAsPodEvent, HostScanEvent, AzureMetadataApi
+from src.core.events.types import Event, NewHostEvent
+from src.core.events import handler
 from __main__ import config
 
 def test_FromPodHostDiscovery():


### PR DESCRIPTION
Unfortunately where the tests subscribe to handlers, that was happening when running kube-hunter as well as when just running the tests! So I have pulled the tests out to a separate directory.