### PR TITLE
python3.7 in dockerfile and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
     #- python: 3.4
     #- python: 3.5
     - python: 3.6
-    #- python: 3.7
-    #  dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     #  sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 install:
   - pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.15-alpine3.8
+FROM python:3.7.2-alpine3.9
 
 RUN apk add --update \
     linux-headers \

--- a/README.md
+++ b/README.md
@@ -86,9 +86,8 @@ Install module dependencies:
 ~~~
 cd ./kube-hunter
 pip install -r requirements.txt
-
-In the case where you have python 3.x in the path as your default, and python2 refers to a python 2.7 executable, use "python2 -m pip install -r requirements.txt"
 ~~~
+
 Run:
 `./kube-hunter.py`
 


### PR DESCRIPTION
* Update docker image to python 3.7.2 and alpine3.9
* Update travis to test python3.7
* Remove part about using python2 in python3-based environment from
README

Closes #103 

Signed-off-by: Weston Steimel <weston.steimel@gmail.com>