### PR TITLE
Update imports and dependencies

### DIFF
--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -46,8 +46,22 @@ else:
 
 from src.core.events import handler
 from src.core.events.types import HuntFinished, HuntStarted
-from src.modules.discovery import HostDiscovery
 from src.modules.discovery.hosts import RunningAsPodEvent, HostScanEvent
+from src.modules.hunting.kubelet import Kubelet
+from src.modules.discovery.apiserver import ApiServerDiscovery
+from src.modules.discovery.proxy import KubeProxy
+from src.modules.discovery.etcd import EtcdRemoteAccess
+from src.modules.discovery.dashboard import KubeDashboard
+from src.modules.discovery.ports import PortDiscovery
+from src.modules.hunting.apiserver import AccessApiServer
+from src.modules.hunting.apiserver import AccessApiServerWithToken
+from src.modules.hunting.proxy import KubeProxy
+from src.modules.hunting.etcd import EtcdRemoteAccess
+from src.modules.hunting.certificates import CertificateDiscovery
+from src.modules.hunting.dashboard import KubeDashboard
+from src.modules.hunting.cvehunter import IsVulnerableToCVEAttack
+from src.modules.hunting.aks import AzureSpnHunter
+from src.modules.hunting.secrets import AccessSecrets
 import src
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 netaddr
 netifaces
-enum34
-scapy
+scapy==2.4.3rc1
 requests
 PrettyTable
 urllib3


### PR DESCRIPTION
When using Pyinstaller to create single application kube-hunter, it fails on conflicts between dependencies and missing imports which this pull request is fixing.