### PR TITLE
Update README to reference non-SSH URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You will need the following installed:
 
 Clone the repository:
 ~~~
-git clone git@github.com:aquasecurity/kube-hunter.git
+git clone https://github.com/aquasecurity/kube-hunter.git
 ~~~
 
 Install module dependencies:


### PR DESCRIPTION
Modify the README to reference the non-SSH URL (which will not work for users that don't have access to the repository).