### PR TITLE
Separated installation process in Python 2.x and 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ git clone https://github.com/aquasecurity/kube-hunter.git
 ~~~
 
 Install module dependencies:
+
+(python 2.x)
+~~~
+cd ./kube-hunter
+pip install -r requirements2.txt
+~~~
+(python 3.x)
 ~~~
 cd ./kube-hunter
 pip install -r requirements.txt

--- a/requirements2.txt
+++ b/requirements2.txt
@@ -7,3 +7,4 @@ urllib3>=1.24.2,<1.25
 ruamel.yaml
 requests_mock
 future
+enum34


### PR DESCRIPTION
Added a separate requirements file, for python2 installation. 
While fixed enum34 issue.
fixes #126 