### PR TITLE
Changed kubelet run handler test to be not a state changing operation

### DIFF
--- a/src/modules/hunting/kubelet.py
+++ b/src/modules/hunting/kubelet.py
@@ -207,14 +207,15 @@ class SecureKubeletPortHunter(Hunter):
 
         # executes one command and returns output
         def test_run_container(self):
+            fake_container_name = "fake-container"
             run_url = self.path + self.Handlers.RUN.value.format(
                 podNamespace=self.pod["namespace"],
                 podID=self.pod["name"],
-                containerName=self.pod["container"],
+                containerName=fake_container_name,
                 cmd = ""
             )
-            status_code = requests.post(run_url, allow_redirects=False, verify=False).status_code 
-            return (status_code != 404 and status_code != 401)
+            output = requests.post(run_url, allow_redirects=False, verify=False).text
+            return output == "container not found (\"{}\")".format(fake_container_name)
 
         # returns list of currently running pods
         def test_running_pods(self):

--- a/src/modules/hunting/kubelet.py
+++ b/src/modules/hunting/kubelet.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 import requests
 import urllib3
+import uuid
 
 from __main__ import config
 from ...core.events import handler
@@ -207,7 +208,7 @@ class SecureKubeletPortHunter(Hunter):
 
         # executes one command and returns output
         def test_run_container(self):
-            fake_container_name = "fake-container"
+            fake_container_name = "fake-container-{}".format(uuid.uuid4())
             run_url = self.path + self.Handlers.RUN.value.format(
                 podNamespace=self.pod["namespace"],
                 podID=self.pod["name"],

--- a/src/modules/hunting/kubelet.py
+++ b/src/modules/hunting/kubelet.py
@@ -4,7 +4,6 @@ from enum import Enum
 
 import requests
 import urllib3
-import uuid
 
 from __main__ import config
 from ...core.events import handler
@@ -208,15 +207,14 @@ class SecureKubeletPortHunter(Hunter):
 
         # executes one command and returns output
         def test_run_container(self):
-            fake_container_name = "fake-container-{}".format(uuid.uuid4())
             run_url = self.path + self.Handlers.RUN.value.format(
-                podNamespace=self.pod["namespace"],
-                podID=self.pod["name"],
-                containerName=fake_container_name,
+                podNamespace='test',
+                podID='test',
+                containerName='test',
                 cmd = ""
             )
-            output = requests.post(run_url, allow_redirects=False, verify=False).text
-            return output == "container not found (\"{}\")".format(fake_container_name)
+            # if we get a Method Not Allowed, we know we passed Authentication and Authorization.
+            return self.session.get(run_url, verify=False).status_code == 405
 
         # returns list of currently running pods
         def test_running_pods(self):


### PR DESCRIPTION
The way we used to passive check the run handler, has appeared to be state changing.
Looking at the source code of the RunHandler core operation in kubernetes:
https://github.com/kubernetes/kubernetes/blob/8de1569ddae62e8fab559fe6bd210a5d6100a277/pkg/kubelet/kubelet_pods.go#L1584
From there we can see it's enough to pass a non-existent container name, to determine the endpoint is open. 