### PR TITLE
New kubectl CVE hunter, detecting CVE-2019-11246 and CVE_2019_1002101

### DIFF
--- a/src/core/types.py
+++ b/src/core/types.py
@@ -38,7 +38,7 @@ class KubernetesCluster():
     name = "Kubernetes Cluster"
 
 class KubectlClient():
-    """The kubectl client binary is used by the user, to interact with the cluster"""
+    """The kubectl client binary is used by the user to interact with the cluster"""
     name = "Kubectl Client"
 
 class Kubelet(KubernetesCluster):

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -37,6 +37,9 @@ class KubernetesCluster():
     """Kubernetes Cluster"""
     name = "Kubernetes Cluster"
 
+class KubectlClient():
+    """The kubectl client binary is used by the user, to interact with the cluster"""
+    name = "Kubectl Client"
 
 class Kubelet(KubernetesCluster):
     """The kubelet is the primary "node agent" that runs on each node"""

--- a/src/modules/discovery/kubectl.py
+++ b/src/modules/discovery/kubectl.py
@@ -1,0 +1,42 @@
+
+import logging
+import subprocess 
+import json
+
+from ...core.types import Discovery
+from ...core.events import handler
+from ...core.events.types import HuntStarted, Event
+
+
+class KubectlClientEvent(Event):
+    """The API server is in charge of all operations on the cluster."""
+    def __init__(self, version):
+        self.version = version
+
+# Will be triggered on start of every hunt 
+@handler.subscribe(HuntStarted)
+class KubectlClientDiscovery(Discovery):
+    """Kubectl Client Discovery
+    Checks for the existence of a local kubectl client
+    """
+    def __init__(self, event):
+        self.event = event
+
+    def get_kubectl_binary_version(self):
+        version = None
+        try:
+            versionInfo = subprocess.check_output("kubectl version --client", stderr=subprocess.STDOUT)
+            if b"GitVersion" in versionInfo:
+                # extracting version from kubectl output
+                versionInfo = versionInfo.decode()
+                start = versionInfo.find('GitVersion')
+                version = versionInfo[start + len("GitVersion':\"") : versionInfo.find("\",", start)]
+        except Exception as x:
+            logging.debug("Could not find kubectl client")
+        return version
+    
+    def execute(self):
+        logging.debug("Attempting to discover a local kubectl client")
+        version = self.get_kubectl_binary_version() 
+        if version:
+            self.publish_event(KubectlClientEvent(version=version))

--- a/src/modules/discovery/kubectl.py
+++ b/src/modules/discovery/kubectl.py
@@ -13,6 +13,9 @@ class KubectlClientEvent(Event):
     def __init__(self, version):
         self.version = version
 
+    def location(self):
+        return "local machine"
+
 # Will be triggered on start of every hunt 
 @handler.subscribe(HuntStarted)
 class KubectlClientDiscovery(Discovery):

--- a/src/modules/discovery/kubectl.py
+++ b/src/modules/discovery/kubectl.py
@@ -28,6 +28,7 @@ class KubectlClientDiscovery(Discovery):
     def get_kubectl_binary_version(self):
         version = None
         try:
+            # kubectl version --client does not make any connection to the cluster/internet whatsoever.
             versionInfo = subprocess.check_output("kubectl version --client", stderr=subprocess.STDOUT)
             if b"GitVersion" in versionInfo:
                 # extracting version from kubectl output

--- a/src/modules/hunting/kubectl.py
+++ b/src/modules/hunting/kubectl.py
@@ -1,0 +1,52 @@
+import logging
+
+from ...core.events import handler
+from ...core.types import Hunter, RemoteCodeExec, KubectlClient
+from ...core.events.types import Vulnerability, Event
+from ..discovery.kubectl import KubectlClientEvent
+
+from distutils.version import LooseVersion, StrictVersion
+
+class KubectlCopyVulnerability(Vulnerability, Event):
+    """The kubectl client is vulnerable to CVE-2019-11246, an attacker could potentially execute arbitrary code on the client's machine"""
+    def __init__(self, binary_version):
+        Vulnerability.__init__(self, KubectlClient, "Kubectl Copy Vulnerability", category=RemoteCodeExec)
+        self.binary_version = binary_version
+        self.evidence = "kubectl version: {}".format(self.binary_version)
+
+
+@handler.subscribe(KubectlClientEvent)
+class KubectlCopyHunter(Hunter):
+    """Kubectl Copy Vulnerability Hunter
+    Compares version of the kubectl binary to known CVE-2019-11246 vulnerable versions 
+    """
+    def __init__(self, event):
+        self.event = event
+        self.fixed_versions = ['1.12.9', '1.13.6', '1.14.2'] # ordered
+
+    def is_vulnerable(self, binary_v):
+        logging.debug("Passive hunter is comparing the kubectl binary version to vulnerable versions")
+        # in case version is in short version, converting
+        if len(LooseVersion(binary_v).version) < 3:
+            binary_v += '.0'
+
+        vulnerable = False
+        if binary_v not in self.fixed_versions:            
+            for fix_v in self.fixed_versions:
+                fix_v = LooseVersion(fix_v)
+                base_v = '.'.join(map(lambda x: str(x), fix_v.version[:2]) )
+
+                if binary_v.startswith(base_v): 
+                    if LooseVersion(binary_v) < fix_v:
+                        vulnerable = True
+                        break
+        
+        # if version is smaller than smaller fix version
+        if not vulnerable and LooseVersion(binary_v) < LooseVersion(self.fixed_versions[0]):
+            vulnerable = True
+        logging.debug("Could not match kubectl with known fix versions, determining vulnerable to kubectl cp vuln")
+        return vulnerable
+
+    def execute(self):
+        if self.is_vulnerable(self.event.version):
+            self.publish_event(KubectlCopyVulnerability(binary_version=self.event.version))

--- a/src/modules/hunting/kubectl.py
+++ b/src/modules/hunting/kubectl.py
@@ -44,7 +44,7 @@ class KubectlCopyHunter(Hunter):
         # if version is smaller than smaller fix version
         if not vulnerable and LooseVersion(binary_v) < LooseVersion(self.fixed_versions[0]):
             vulnerable = True
-        logging.debug("Could not match kubectl with known fix versions, determining vulnerable to kubectl cp vuln")
+
         return vulnerable
 
     def execute(self):

--- a/src/modules/hunting/kubectl.py
+++ b/src/modules/hunting/kubectl.py
@@ -7,46 +7,58 @@ from ..discovery.kubectl import KubectlClientEvent
 
 from distutils.version import LooseVersion, StrictVersion
 
-class KubectlCopyVulnerability(Vulnerability, Event):
+class IncompleteFixToKubectlCpVulnerability(Vulnerability, Event):
     """The kubectl client is vulnerable to CVE-2019-11246, an attacker could potentially execute arbitrary code on the client's machine"""
     def __init__(self, binary_version):
-        Vulnerability.__init__(self, KubectlClient, "Kubectl Copy Vulnerability", category=RemoteCodeExec)
+        Vulnerability.__init__(self, KubectlClient, "Kubectl Vulnerable To CVE-2019-11246", category=RemoteCodeExec)
+        self.binary_version = binary_version
+        self.evidence = "kubectl version: {}".format(self.binary_version)
+
+class KubectlCpVulnerability(Vulnerability, Event):
+    """The kubectl client is vulnerable to CVE-2019-1002101, an attacker could potentially execute arbitrary code on the client's machine"""
+    def __init__(self, binary_version):
+        Vulnerability.__init__(self, KubectlClient, "Kubectl Vulnerable To CVE-2019-1002101", category=RemoteCodeExec)
         self.binary_version = binary_version
         self.evidence = "kubectl version: {}".format(self.binary_version)
 
 
 @handler.subscribe(KubectlClientEvent)
-class KubectlCopyHunter(Hunter):
-    """Kubectl Copy Vulnerability Hunter
-    Compares version of the kubectl binary to known CVE-2019-11246 vulnerable versions 
+class KubectlCVEHunter(Hunter):
+    """Kubectl CVE Hunter
+    Compares version of the kubectl binary to known CVE affected versions
     """
     def __init__(self, event):
         self.event = event
-        self.fixed_versions = ['1.12.9', '1.13.6', '1.14.2'] # ordered
 
-    def is_vulnerable(self, binary_v):
+    def is_older_than(self, fix_versions, check_version):
+        """Function determines if a version is vulnerable, by comparing to given fix versions"""
         logging.debug("Passive hunter is comparing the kubectl binary version to vulnerable versions")
         # in case version is in short version, converting
-        if len(LooseVersion(binary_v).version) < 3:
-            binary_v += '.0'
+        if len(LooseVersion(check_version).version) < 3:
+            check_version += '.0'
 
         vulnerable = False
-        if binary_v not in self.fixed_versions:            
-            for fix_v in self.fixed_versions:
+        if check_version not in fix_versions:
+            for fix_v in fix_versions:
                 fix_v = LooseVersion(fix_v)
                 base_v = '.'.join(map(lambda x: str(x), fix_v.version[:2]) )
 
-                if binary_v.startswith(base_v): 
-                    if LooseVersion(binary_v) < fix_v:
+                if check_version.startswith(base_v):
+                    if LooseVersion(check_version) < fix_v:
                         vulnerable = True
                         break
-        
         # if version is smaller than smaller fix version
-        if not vulnerable and LooseVersion(binary_v) < LooseVersion(self.fixed_versions[0]):
+        if not vulnerable and LooseVersion(check_version) < LooseVersion(fix_versions[0]):
             vulnerable = True
 
         return vulnerable
 
     def execute(self):
-        if self.is_vulnerable(self.event.version):
-            self.publish_event(KubectlCopyVulnerability(binary_version=self.event.version))
+        cve_2019_1002101_fix_versions = ['1.11.9', '1.12.7', '1.13.5' '1.14.0']
+        cve_2019_11246_fix_versions = ['1.12.9', '1.13.6', '1.14.2']
+
+        if self.is_older_than(fix_versions=cve_2019_1002101_fix_versions, check_version=self.event.version):
+            self.publish_event(KubectlCpVulnerability(binary_version=self.event.version))
+
+        if self.is_older_than(fix_versions=cve_2019_11246_fix_versions, check_version=self.event.version):
+            self.publish_event(IncompleteFixToKubectlCpVulnerability(binary_version=self.event.version))


### PR DESCRIPTION
Added: 
* Passive Hunter: "KubectlCVEHunter"
* Discovery Hunter: "KubectlClientDiscovery"
* Component: "KubectlClient"
the hunters, try to get the kubectl version, if kubectl is available in the context of kube-hunter, the PassiveHunter will compare the version to the known fix versions, if it's a vulnerable version, a new vulnerability will rise: appropriate cves vulnerabilities
dependent on #140 