### PR TITLE
Changed legacy host:port in collector to use location

### DIFF
--- a/src/modules/report/collector.py
+++ b/src/modules/report/collector.py
@@ -53,10 +53,9 @@ class Collector(object):
             services.append(self.event)
             services_lock.release()
             import datetime
-            logging.info("|\n| {name}:\n|   type: open service\n|   service: {name}\n|_  host: {host}:{port}".format(
-                host=self.event.host,
-                port=self.event.port,
+            logging.info("|\n| {name}:\n|   type: open service\n|   service: {name}\n|_  location: {location}".format(
                 name=self.event.get_name(),
+                location=self.event.location(),
                 time=datetime.time()
             ))
 
@@ -65,10 +64,9 @@ class Collector(object):
             vulnerabilities.append(self.event)
             vulnerabilities_lock.release()
             logging.info(
-                "|\n| {name}:\n|   type: vulnerability\n|   host: {host}:{port}\n|   description: \n{desc}".format(
+                "|\n| {name}:\n|   type: vulnerability\n|   location: {location}\n|   description: \n{desc}".format(
                     name=self.event.get_name(),
-                    host=self.event.host,
-                    port=self.event.port,
+                    location=self.event.location(),
                     desc=wrap_last_line(console_trim(self.event.explain(), '|     '))
                 ))
 


### PR DESCRIPTION
Until now, the collector was using the legacy host:port format on reporting, but this is changed, and the location now should be achieved from the location function of the event. This made events that had a custom location display None:None.

Before:
```
|
| Kubectl Vulnerable To CVE-2019-1002101:
|   type: vulnerability
|   host: None:None
|   description:
|     The kubectl client is vulnerable to
|     CVE-2019-1002101, an attacker could potentially execute arbitrary
|_    code on the client's machine
```

Now:
```
|
| Kubectl Vulnerable To CVE-2019-1002101:
|   type: vulnerability
|   location: local machine
|   description:
|     The kubectl client is vulnerable to
|     CVE-2019-1002101, an attacker could potentially execute arbitrary
|_    code on the client's machine
```