### PR TITLE
Pyinstaller/py2exe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ pip install -r requirements.txt
 Run:
 `./kube-hunter.py`
 
+_If you want to use pyinstaller/py2exe you need to first run the install_imports.py script._
 ### Container
 Aqua Security maintains a containerised version of kube-hunter at `aquasec/kube-hunter`. _(Please note this is not currently up to date due to an issue in an underlying dependency that is [blocking the automated build](https://github.com/aquasecurity/kube-hunter/issues/112))_. This container includes this source code, plus an additional (closed source) reporting plugin for uploading results into a report that can be viewed at [kube-hunter.aquasec.com](https://kube-hunter.aquasec.com). Please note that running the `aquasec/kube-hunter` container and uploading reports data are subject to additional [terms and conditions](https://kube-hunter.aquasec.com/eula.html).
 

--- a/install_imports.py
+++ b/install_imports.py
@@ -14,3 +14,4 @@ def install_static_imports(path):
 install_static_imports("src/modules/discovery/")
 install_static_imports("src/modules/hunting/")
 install_static_imports("src/modules/report/")
+install_static_imports("plugins/")

--- a/install_imports.py
+++ b/install_imports.py
@@ -1,0 +1,16 @@
+from os.path import basename
+import glob
+
+def get_py_files(path):
+    for py_file in glob.glob("{}*.py".format(path)):
+        if not py_file.endswith("__init__.py"):
+            yield basename(py_file)[:-3]
+
+def install_static_imports(path):
+    with open("{}__init__.py".format(path), 'w') as init_f:
+        for pf in get_py_files(path):
+            init_f.write("from .{} import *\n".format(pf))
+
+install_static_imports("src/modules/discovery/")
+install_static_imports("src/modules/hunting/")
+install_static_imports("src/modules/report/")

--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -42,21 +42,6 @@ else:
 from src.core.events import handler
 from src.core.events.types import HuntFinished, HuntStarted
 from src.modules.discovery.hosts import RunningAsPodEvent, HostScanEvent
-from src.modules.hunting.kubelet import Kubelet
-from src.modules.discovery.apiserver import ApiServerDiscovery
-from src.modules.discovery.proxy import KubeProxy
-from src.modules.discovery.etcd import EtcdRemoteAccess
-from src.modules.discovery.dashboard import KubeDashboard
-from src.modules.discovery.ports import PortDiscovery
-from src.modules.hunting.apiserver import AccessApiServer
-from src.modules.hunting.apiserver import AccessApiServerWithToken
-from src.modules.hunting.proxy import KubeProxy
-from src.modules.hunting.etcd import EtcdRemoteAccess
-from src.modules.hunting.certificates import CertificateDiscovery
-from src.modules.hunting.dashboard import KubeDashboard
-from src.modules.hunting.cvehunter import IsVulnerableToCVEAttack
-from src.modules.hunting.aks import AzureSpnHunter
-from src.modules.hunting.secrets import AccessSecrets
 import src
 
 


### PR DESCRIPTION
Because of how pyinstaller interpreters and process imports, we needed to explicitly specify in the main file, which hunters to load. This conflicted the goal of dynamically importing the modules. 

To work around this issue without the need to explicitly add import lines, added a new script: `install_imports.py` which essentially, replaces the `__init__.py` file inside the relevant packages, with static imports.

Also, removed unnecessary imports from main file.
