### PR TITLE
Fixed Bugs in Api Server Hunting

### DIFF
--- a/src/modules/discovery/hosts.py
+++ b/src/modules/discovery/hosts.py
@@ -25,7 +25,7 @@ class RunningAsPodEvent(Event):
         self.kubeservicehost = os.environ.get("KUBERNETES_SERVICE_HOST", None)
         self.auth_token = self.get_service_account_file("token")
         if self.auth_token:
-            self.account_name = self.parse_token(self.auth_token)
+            self.account_name = self.parse_token(self.auth_token).get('sub')
 
     # Event's logical location to be used mainly for reports.
     def location(self):

--- a/src/modules/hunting/apiserver.py
+++ b/src/modules/hunting/apiserver.py
@@ -206,7 +206,7 @@ class AccessApiServer(Hunter):
         self.event = event
         self.path = "{}://{}:{}".format(self.event.protocol, self.event.host, self.event.port)
         self.headers = {}
-        self.with_token = False
+        self.with_token = self.event.auth_token is not None 
 
     def access_api_server(self):
         logging.debug('Passive Hunter is attempting to access the API at {}'.format(self.path))

--- a/src/modules/hunting/apiserver.py
+++ b/src/modules/hunting/apiserver.py
@@ -196,7 +196,6 @@ class ApiServerPassiveHunterFinished(Event):
 
 
 # This Hunter checks what happens if we try to access the API Server without a service account token
-# If we have a service account token we'll also trigger AccessApiServerWithToken below
 @handler.subscribe(ApiServer)
 class AccessApiServer(Hunter):
     """ API Server Hunter

--- a/tests/hunting/test_apiserver_hunter.py
+++ b/tests/hunting/test_apiserver_hunter.py
@@ -45,6 +45,9 @@ def test_AccessApiServer():
                             {"metadata":{"name":"podB", "namespace":"namespaceB"}}]}')
         m.get('https://mockkubernetes:443/apis/rbac.authorization.k8s.io/v1/roles', status_code=403)
         m.get('https://mockkubernetes:443/apis/rbac.authorization.k8s.io/v1/clusterroles', text='{"items":[]}')
+        m.get('https://mockkubernetes:443/api/v1/namespaces/default/pods',
+            text='{"items":[{"metadata":{"name":"podA", "namespace":"default"}}, \
+                            {"metadata":{"name":"podB", "namespace":"default"}}]}')
 
         h = AccessApiServer(e)
         h.execute()
@@ -65,7 +68,10 @@ def test_AccessApiServer():
         m.get('https://mockkubernetesToken:443/apis/rbac.authorization.k8s.io/v1/roles', status_code=403)
         m.get('https://mockkubernetesToken:443/apis/rbac.authorization.k8s.io/v1/clusterroles', 
             text='{"items":[{"metadata":{"name":"my-role"}}]}')
-
+        m.get('https://mockkubernetesToken:443/api/v1/namespaces/default/pods',
+            text='{"items":[{"metadata":{"name":"podA", "namespace":"default"}}, \
+                            {"metadata":{"name":"podB", "namespace":"default"}}]}')
+        
         e.auth_token = "so-secret"
         e.host = "mockKubernetesToken"
         h = AccessApiServer(e)

--- a/tests/hunting/test_apiserver_hunter.py
+++ b/tests/hunting/test_apiserver_hunter.py
@@ -1,7 +1,7 @@
 import requests_mock
 import time
 
-from src.modules.hunting.apiserver import AccessApiServer, AccessApiServerWithToken, ServerApiAccess, AccessApiServerActive
+from src.modules.hunting.apiserver import AccessApiServer, ServerApiAccess, AccessApiServerActive
 from src.modules.hunting.apiserver import ListNamespaces, ListPodsAndNamespaces, ListRoles, ListClusterRoles
 from src.modules.hunting.apiserver import ApiServerPassiveHunterFinished
 from src.modules.hunting.apiserver import CreateANamespace, DeleteANamespace
@@ -21,7 +21,7 @@ def test_ApiServerToken():
     e.auth_token = "my-secret-token"
 
     # Test that the pod's token is passed on through the event
-    h = AccessApiServerWithToken(e)
+    h = AccessApiServer(e)
     assert h.event.auth_token == "my-secret-token"
 
     # This test doesn't generate any events
@@ -68,7 +68,7 @@ def test_AccessApiServer():
 
         e.auth_token = "so-secret"
         e.host = "mockKubernetesToken"
-        h = AccessApiServerWithToken(e)
+        h = AccessApiServer(e)
         h.execute()
 
         # We should see the same set of events but with the addition of Cluster Roles


### PR DESCRIPTION
### This PR fixed 3 major bugs:
* Removed unnecessary `AccessApiServerWithToken` hunter, this caused duplicates, Hunting with token happens anyway in the normal `AccessApiServer` hunter, if the token exists, (if we want to try hunting without the token as well, we should do that in another way, but don't really see the point if we are running as pod with default service-account)
* Added a default of "default" namespace. for cases of tokens that does not have permission to list namespaces. (without defaulting to this namespace, we miss alot of possible open RBAC configurations)
* A typo was throwing exception and made the AccessApiServerActive fail everytime it tried to delete an item.