### PR TITLE
New Core Feature: Subscribe Once

### DIFF
--- a/src/core/events/handler.py
+++ b/src/core/events/handler.py
@@ -44,6 +44,20 @@ class EventQueue(Queue, object):
 
         return wrapper
 
+    # wrapper takes care of the subscribe once mechanism
+    def subscribe_once(self, event, hook=None, predicate=None):
+        def wrapper(hook):
+            # installing a __new__ magic method on the hunter
+            # which will remove the hunter from the list upon creation
+            def __new__unsubscribe_self(self, cls):
+                handler.hooks[event].remove((hook, predicate))
+                return object.__new__(self)
+            hook.__new__ = __new__unsubscribe_self
+
+            self.subscribe_event(event, hook=hook, predicate=predicate)
+            return hook
+        return wrapper
+
     # getting uninstantiated event object
     def subscribe_event(self, event, hook=None, predicate=None):
         if ActiveHunter in hook.__mro__:

--- a/tests/core/test_subscribe.py
+++ b/tests/core/test_subscribe.py
@@ -1,0 +1,50 @@
+import time
+
+from src.core.types import Hunter
+from src.core.events.types import Event, Service 
+from src.core.events import handler
+
+counter = 0
+
+class OnceOnlyEvent(Service, Event):
+    def __init__(self):
+        Service.__init__(self, "Test Once Service")
+
+class RegularEvent(Service, Event):
+    def __init__(self):
+        Service.__init__(self, "Test Service")
+
+@handler.subscribe_once(OnceOnlyEvent)
+class OnceHunter(Hunter):
+    def __init__(self, event):
+        global counter
+        counter += 1
+
+@handler.subscribe(RegularEvent)
+class RegularHunter(Hunter):
+    def __init__(self, event):
+        global counter
+        counter += 1
+
+
+def test_subscribe_mechanism():
+    global counter
+    
+    # first test normal subscribe and publish works
+    handler.publish_event(RegularEvent())
+    handler.publish_event(RegularEvent())
+    handler.publish_event(RegularEvent())
+    
+    time.sleep(0.02)
+    assert counter == 3
+    counter = 0
+    
+    # testing the subscribe_once mechanism
+    handler.publish_event(OnceOnlyEvent())
+    handler.publish_event(OnceOnlyEvent())
+    handler.publish_event(OnceOnlyEvent())
+
+    time.sleep(0.02)
+    # should have been triggered once
+    assert counter == 1
+        


### PR DESCRIPTION
Introducing, a subscribe once decorator. 
This allows a hunter to execute only once on the first matched event that's getting published.

### Motivation
When the #162 is merged, the CVE hunter will be triggered on every `K8sVersionDisclosure` event. But in reality we want to only check the version once, we don't care where it came from.

### Implementation and usage
Example:
```python
@handler.subscribe_once(SomeEvent)
class OnceOnlyHunter(Hunter):
    def __init__(self, event):
        self.event = event
    def execute(self):
        print('executed')
```
In this example, no matter how many times `SomeEvent` will get published,
The hunter will run just on the first publish.

The implementation is using the `__new__` magic method in python, to install a `unregister` function on the hook when the decorator function is executed.
so when the first Hunter will be initialized, (actually just before) it will unregister itself from the event

_Tests were added_