### PR TITLE
Changed name of Subnet scanning to - Interface Scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To specify remote machines for hunting, select option 1 or use the `--remote` op
 `./kube-hunter.py --remote some.node.com`
 
 2. **interface scanning**
-To specify internal scanning, you can use the `--interface` option. (this will scan all of the machine's network interfaces) Example:
+To specify interface scanning, you can use the `--interface` option. (this will scan all of the machine's network interfaces) Example:
 `./kube-hunter.py --interface`
 
 3. **Network scanning**

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ By default, kube-hunter will open an interactive session, in which you will be a
 To specify remote machines for hunting, select option 1 or use the `--remote` option. Example:
 `./kube-hunter.py --remote some.node.com`
 
-2. **Internal scanning**
-To specify internal scanning, you can use the `--internal` option. (this will scan all of the machine's network interfaces) Example:
-`./kube-hunter.py --internal`
+2. **interface scanning**
+To specify internal scanning, you can use the `--interface` option. (this will scan all of the machine's network interfaces) Example:
+`./kube-hunter.py --interface`
 
 3. **Network scanning**
 To specify a specific CIDR to scan, use the `--cidr` option. Example:

--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -6,7 +6,7 @@ import threading
 
 parser = argparse.ArgumentParser(description='Kube-Hunter - hunts for security weaknesses in Kubernetes clusters')
 parser.add_argument('--list', action="store_true", help="displays all tests in kubehunter (add --active flag to see active tests)")
-parser.add_argument('--internal', action="store_true", help="set hunting of all internal network interfaces")
+parser.add_argument('--interface', action="store_true", help="set hunting of all network interfaces")
 parser.add_argument('--pod', action="store_true", help="set hunter as an insider pod")
 parser.add_argument('--quick', action="store_true", help="Prefer quick scan (subnet 24)")
 parser.add_argument('--cidr', type=str, help="set an ip range to scan, example: 192.168.0.0/16")
@@ -63,7 +63,7 @@ import src
 def interactive_set_config():
     """Sets config manually, returns True for success"""
     options = [("Remote scanning", "scans one or more specific IPs or DNS names"),
-    ("Subnet scanning","scans subnets on all local network interfaces"),
+    ("Interface scanning","scans subnets on all local network interfaces"),
     ("IP range scanning","scans a given IP range")]
     
     print("Choose one of the options below:")
@@ -73,7 +73,7 @@ def interactive_set_config():
     if choice == '1':
         config.remote = input("Remotes (separated by a ','): ").replace(' ', '').split(',')
     elif choice == '2':
-        config.internal = True
+        config.interface = True
     elif choice == '3': 
         config.cidr = input("CIDR (example - 192.168.1.0/24): ").replace(' ', '')
     else: 
@@ -105,7 +105,7 @@ def main():
         config.pod, 
         config.cidr,
         config.remote, 
-        config.internal
+        config.interface
     ]
     try:
         if config.list:

--- a/runtest.py
+++ b/runtest.py
@@ -3,7 +3,7 @@ import pytest
 
 parser = argparse.ArgumentParser(description='Kube-Hunter tests')
 parser.add_argument('--list', action="store_true", help="displays all tests in kubehunter (add --active flag to see active tests)")
-parser.add_argument('--internal', action="store_true", help="set hunting of all internal network interfaces")
+parser.add_argument('--interface', action="store_true", help="set hunting of all interface network interfaces")
 parser.add_argument('--pod', action="store_true", help="set hunter as an insider pod")
 parser.add_argument('--quick', action="store_true", help="Prefer quick scan (subnet 24)")
 parser.add_argument('--cidr', type=str, help="set an ip range to scan, example: 192.168.0.0/16")

--- a/src/modules/discovery/hosts.py
+++ b/src/modules/discovery/hosts.py
@@ -161,7 +161,7 @@ class HostDiscovery(Discovery):
             cloud = HostDiscoveryHelpers.get_cloud(ip)
             for ip in HostDiscoveryHelpers.generate_subnet(ip, sn=sn):
                 self.publish_event(NewHostEvent(host=ip, cloud=cloud))                
-        elif config.internal:
+        elif config.interface:
             self.scan_interfaces()
         elif len(config.remote) > 0:
             for host in config.remote:


### PR DESCRIPTION
The usage of internal scanning was not clear, so this PR changes the names of the scanning method.
From now on, **the internal scanning should be referred to as interface scanning.**