### PR TITLE
Ignore downstream version flag

### DIFF
--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -9,6 +9,7 @@ parser.add_argument('--list', action="store_true", help="displays all tests in k
 parser.add_argument('--interface', action="store_true", help="set hunting of all network interfaces")
 parser.add_argument('--pod', action="store_true", help="set hunter as an insider pod")
 parser.add_argument('--quick', action="store_true", help="Prefer quick scan (subnet 24)")
+parser.add_argument('--ignore-downstream', action="store_true", help="Ignore patched kubernetes components")
 parser.add_argument('--cidr', type=str, help="set an ip range to scan, example: 192.168.0.0/16")
 parser.add_argument('--mapping', action="store_true", help="outputs only a mapping of the cluster's nodes")
 parser.add_argument('--remote', nargs='+', metavar="HOST", default=list(), help="one or more remote ip/dns to hunt")

--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -9,7 +9,7 @@ parser.add_argument('--list', action="store_true", help="displays all tests in k
 parser.add_argument('--interface', action="store_true", help="set hunting of all network interfaces")
 parser.add_argument('--pod', action="store_true", help="set hunter as an insider pod")
 parser.add_argument('--quick', action="store_true", help="Prefer quick scan (subnet 24)")
-parser.add_argument('--ignore-downstream', action="store_true", help="Ignore patched kubernetes components")
+parser.add_argument('--ignore-downstream', action="store_true", help="Ignore patched kubernetes versions")
 parser.add_argument('--cidr', type=str, help="set an ip range to scan, example: 192.168.0.0/16")
 parser.add_argument('--mapping', action="store_true", help="outputs only a mapping of the cluster's nodes")
 parser.add_argument('--remote', nargs='+', metavar="HOST", default=list(), help="one or more remote ip/dns to hunt")

--- a/runtest.py
+++ b/runtest.py
@@ -6,7 +6,7 @@ parser.add_argument('--list', action="store_true", help="displays all tests in k
 parser.add_argument('--interface', action="store_true", help="set hunting of all interface network interfaces")
 parser.add_argument('--pod', action="store_true", help="set hunter as an insider pod")
 parser.add_argument('--quick', action="store_true", help="Prefer quick scan (subnet 24)")
-parser.add_argument('--ignore-downstream', action="store_true", help="Ignore patched kubernetes components")
+parser.add_argument('--ignore-downstream', action="store_true", help="Ignore patched kubernetes versions")
 parser.add_argument('--cidr', type=str, help="set an ip range to scan, example: 192.168.0.0/16")
 parser.add_argument('--mapping', action="store_true", help="outputs only a mapping of the cluster's nodes")
 parser.add_argument('--remote', nargs='+', metavar="HOST", default=list(), help="one or more remote ip/dns to hunt")

--- a/runtest.py
+++ b/runtest.py
@@ -6,6 +6,7 @@ parser.add_argument('--list', action="store_true", help="displays all tests in k
 parser.add_argument('--interface', action="store_true", help="set hunting of all interface network interfaces")
 parser.add_argument('--pod', action="store_true", help="set hunter as an insider pod")
 parser.add_argument('--quick', action="store_true", help="Prefer quick scan (subnet 24)")
+parser.add_argument('--ignore-downstream', action="store_true", help="Ignore patched kubernetes components")
 parser.add_argument('--cidr', type=str, help="set an ip range to scan, example: 192.168.0.0/16")
 parser.add_argument('--mapping', action="store_true", help="outputs only a mapping of the cluster's nodes")
 parser.add_argument('--remote', nargs='+', metavar="HOST", default=list(), help="one or more remote ip/dns to hunt")

--- a/tests/hunting/test_cvehunting.py
+++ b/tests/hunting/test_cvehunting.py
@@ -69,7 +69,8 @@ class test_CveUtils(object):
             ('v1.2+3', True),
             ('v1.2~3', True),
             ('v1.2+a3f5cb2', True),
-            ('v1.2-9287543', True)
+            ('v1.2-9287543', True),
+            ('v1.13.9-gke.3', True)
         )
 
         for version, expected in test_cases:
@@ -80,6 +81,7 @@ class test_CveUtils(object):
         test_cases = (
             ('v2.2-abcd', ['v1.1', 'v2.3'], False),
             ('v2.2-abcd', ['v1.1', 'v2.2'], False),
+            ('v1.13.9-gke.3', ['v1.14.8'], False)
         )
 
         for check_version, fix_versions, expected in test_cases:


### PR DESCRIPTION
This commit adds `--ignore-downstream` flag to kube-hunter.
Enabling the flag will make kube-hunter considering patched versions
as not vulnerable.
Resolves #179