### PR TITLE
document api access vulnerabilities

### DIFF
--- a/docs/kb/KHV007.md
+++ b/docs/kb/KHV007.md
@@ -17,4 +17,4 @@ Review the RBAC permissions to Kubernetes API server for the anonymous and defau
 ## References
 
 - [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
-- [KHV005 - Access to Kubernetes API]({% link kb/KHV005.md %})
+- [KHV005 - Access to Kubernetes API]({{ site.baseurl }}{% link kb/KHV005.md %})

--- a/docs/kb/KHV007.md
+++ b/docs/kb/KHV007.md
@@ -1,0 +1,20 @@
+---
+id: KHV007
+title: Specific Access to Kubernetes API
+categories: [Access Risk]
+---
+
+# KHV007 - Specific Access to Kubernetes API
+
+## Issue description
+
+kube-hunter was able to perform the action specified by the reported vulnerability (check the report for more information). This may or may not be a problem, depending on your cluster setup and preferences.
+
+## Remediation
+
+Review the RBAC permissions to Kubernetes API server for the anonymous and default service account.
+
+## References
+
+- [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [KHV005 - Access to Kubernetes API]({% link kb/KHV005.md %})

--- a/src/modules/hunting/apiserver.py
+++ b/src/modules/hunting/apiserver.py
@@ -41,7 +41,7 @@ class ApiInfoDisclosure(Vulnerability, Event):
             name +=" using service account token"
         else:
             name +=" as anonymous user"
-        Vulnerability.__init__(self, KubernetesCluster, name=name, category=InformationDisclosure)
+        Vulnerability.__init__(self, KubernetesCluster, name=name, category=InformationDisclosure, vid="KHV007")
         self.evidence = evidence
 
 class ListPodsAndNamespaces(ApiInfoDisclosure):


### PR DESCRIPTION
This adds general documentation for the following class of "vulnerabilities":

CreateANamespace
DeleteANamespace
CreateARole
CreateAClusterRole
PatchARole
PatchAClusterRole
DeleteARole
DeleteAClusterRole
CreateAPod
CreateAPrivilegedPod
PatchAPod
DeleteAPod

