### PR TITLE
document DNS spoofing vulnerability

### DIFF
--- a/docs/kb/KHV030.md
+++ b/docs/kb/KHV030.md
@@ -18,6 +18,6 @@ Consider using DNS over TLS. CoreDNS (the common DNS server for Kubernetes) supp
 ## References
 
 - [DNS Spoofing on Kubernetes Clusters](https://blog.aquasec.com/dns-spoofing-kubernetes-clusters)
-- [KHV020 - Possible Arp Spoof]({% link kb/KHV020.md %})
+- [KHV020 - Possible Arp Spoof]({{ site.baseurl }}{% link kb/KHV020.md %})
 - [CoreDNS DNS over TLS](https://coredns.io/manual/toc/#specifying-a-protocol)
 - [DNS over TLS spec](https://tools.ietf.org/html/rfc7858)

--- a/docs/kb/KHV030.md
+++ b/docs/kb/KHV030.md
@@ -1,0 +1,23 @@
+---
+id: KHV030
+title: Possible DNS Spoof
+categories: [Identity Theft]
+---
+
+# KHV030 - Possible DNS Spoof
+
+## Issue description
+
+Your Kubernetes DNS setup is vulnerable to spoofing attacks which impersonate your DNS for malicious purposes.  
+In this case the exploited vulnerability was ARP spoofing, but other methods could be used as well.
+
+## Remediation
+
+Consider using DNS over TLS. CoreDNS (the common DNS server for Kubernetes) supports this out of the box, but your client applications might not.
+
+## References
+
+- [DNS Spoofing on Kubernetes Clusters](https://blog.aquasec.com/dns-spoofing-kubernetes-clusters)
+- [KHV020 - Possible Arp Spoof]({% link kb/KHV020.md %})
+- [CoreDNS DNS over TLS](https://coredns.io/manual/toc/#specifying-a-protocol)
+- [DNS over TLS spec](https://tools.ietf.org/html/rfc7858)

--- a/src/modules/hunting/dns.py
+++ b/src/modules/hunting/dns.py
@@ -12,7 +12,7 @@ from scapy.all import IP, ICMP, UDP, DNS, DNSQR, ARP, Ether, sr1, srp1, srp
 class PossibleDnsSpoofing(Vulnerability, Event):
     """A malicous pod running on the cluster could potentially run a DNS Spoof attack and perform a MITM attack on applications running in the cluster."""
     def __init__(self, kubedns_pod_ip):
-        Vulnerability.__init__(self, KubernetesCluster, "Possible DNS Spoof", category=IdentityTheft)
+        Vulnerability.__init__(self, KubernetesCluster, "Possible DNS Spoof", category=IdentityTheft, vid="KHV030")
         self.kubedns_pod_ip = kubedns_pod_ip
         self.evidence = "kube-dns at: {}".format(self.kubedns_pod_ip)
 


### PR DESCRIPTION
note that even though the hunter exploits the ARP spoofing vulnerability https://github.com/aquasecurity/kube-hunter/blob/master/docs/kb/KHV020.md, it is still distinct as there could be other ways to spoof. I tried not to mix the two.