### PR TITLE
fix navigation url when searching for kb article

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -62,7 +62,7 @@
     </div>
     <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
     <script type="text/javascript">
-        var articleUrlPrefix = "{{ site.url }}/kb/";
+        var articleUrlTemplate = "{% link kb/KHV002.md %}";
         var searchInput = document.getElementById("searchInput");
         var searchButton = document.getElementById("searchButton");
         searchInput.addEventListener("keyup", function(event) {
@@ -81,7 +81,7 @@
             if (!searchTerm.startsWith("KHV")) {
                 searchTerm = "KHV" + searchTerm;
             }
-            window.location = articleUrlPrefix + searchTerm;
+            window.location = articleUrlTemplate.replace("KHV002",searchTerm);
         }
     </script>
     {% if site.google_analytics %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -62,7 +62,7 @@
     </div>
     <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
     <script type="text/javascript">
-        var articleUrlTemplate = "{% link kb/KHV002.md %}";
+        var articleUrlTemplate = "{{ site.baseurl }}{% link kb/KHV002.md %}";
         var searchInput = document.getElementById("searchInput");
         var searchButton = document.getElementById("searchButton");
         searchInput.addEventListener("keyup", function(event) {


### PR DESCRIPTION
when hosted under a path (for example, `http://host/sub`), the composed link doesn't account for the path (`/sub`). This PR fixes this by using Jekyll's `link` tag to build the URL