### PR TITLE
kb: typo endoint -> endpoint

### DIFF
--- a/docs/kb/KHV003.md
+++ b/docs/kb/KHV003.md
@@ -8,7 +8,7 @@ categories: [Information Disclosure]
 
 ## Issue description
 
-Microsoft Azure provides an internal HTTP endpoint that exposes information from the cloud platform to workloads running in a VM. The endoint is accessible to every workload running in the VM. An attacker that is able to execute a pod in the cluster may be able to query the metadata service and discover additional information about the environment.
+Microsoft Azure provides an internal HTTP endpoint that exposes information from the cloud platform to workloads running in a VM. The endpoint is accessible to every workload running in the VM. An attacker that is able to execute a pod in the cluster may be able to query the metadata service and discover additional information about the environment.
 
 ## Remediation
 

--- a/docs/kb/KHV037.md
+++ b/docs/kb/KHV037.md
@@ -8,7 +8,7 @@ categories: [Information Disclosure]
 
 ## Issue description
 
-The kubelet is is leaking container logs via the `/containerLogs` endpoint. This endoint is exposed as part of the kubelet's debug handlers.
+The kubelet is is leaking container logs via the `/containerLogs` endpoint. This endpoint is exposed as part of the kubelet's debug handlers.
 
 
 ## Remediation

--- a/docs/kb/KHV038.md
+++ b/docs/kb/KHV038.md
@@ -8,7 +8,7 @@ categories: [Information Disclosure]
 
 ## Issue description
 
-The kubelet is is leaking information about runnig pods via the `/runningpods` endpoint. This endoint is exposed as part of the kubelet's debug handlers.
+The kubelet is is leaking information about runnig pods via the `/runningpods` endpoint. This endpoint is exposed as part of the kubelet's debug handlers.
 
 
 ## Remediation

--- a/docs/kb/KHV039.md
+++ b/docs/kb/KHV039.md
@@ -8,7 +8,7 @@ categories: [Remote Code Execution]
 
 ## Issue description
 
-An attacker could run arbitrary commands on a container via the the kubelet's `/exec` endpoint. This endoint is exposed as part of the kubelet's debug handlers.
+An attacker could run arbitrary commands on a container via the the kubelet's `/exec` endpoint. This endpoint is exposed as part of the kubelet's debug handlers.
 
 ## Remediation
 

--- a/docs/kb/KHV040.md
+++ b/docs/kb/KHV040.md
@@ -8,7 +8,7 @@ categories: [Remote Code Execution]
 
 ## Issue description
 
-An attacker could run arbitrary commands on a container via the the kubelet's `/run` endpoint. This endoint is exposed as part of the kubelet's debug handlers.
+An attacker could run arbitrary commands on a container via the the kubelet's `/run` endpoint. This endpoint is exposed as part of the kubelet's debug handlers.
 
 ## Remediation
 

--- a/docs/kb/KHV041.md
+++ b/docs/kb/KHV041.md
@@ -8,7 +8,7 @@ categories: [Remote Code Execution]
 
 ## Issue description
 
-An attacker could read and write data from a pod via the the kubelet's `/portForward` endpoint. This endoint is exposed as part of the kubelet's debug handlers.
+An attacker could read and write data from a pod via the the kubelet's `/portForward` endpoint. This endpoint is exposed as part of the kubelet's debug handlers.
 
 ## Remediation
 

--- a/docs/kb/KHV042.md
+++ b/docs/kb/KHV042.md
@@ -8,7 +8,7 @@ categories: [Remote Code Execution]
 
 ## Issue description
 
-An attacker could attach to a running container via a websocket on the the the kubelet's `/attach` endpoint. This endoint is exposed as part of the kubelet's debug handlers.
+An attacker could attach to a running container via a websocket on the the the kubelet's `/attach` endpoint. This endpoint is exposed as part of the kubelet's debug handlers.
 
 ## Remediation
 

--- a/docs/kb/KHV043.md
+++ b/docs/kb/KHV043.md
@@ -8,7 +8,7 @@ categories: [Information Disclosure]
 
 ## Issue description
 
-The kubelet is is leaking it's health information, which may contain sensitive information, via the `/healthz` endpoint. This endoint is exposed as part of the kubelet's debug handlers.
+The kubelet is is leaking it's health information, which may contain sensitive information, via the `/healthz` endpoint. This endpoint is exposed as part of the kubelet's debug handlers.
 
 ## Remediation
 

--- a/docs/kb/KHV045.md
+++ b/docs/kb/KHV045.md
@@ -8,7 +8,7 @@ categories: [Information Disclosure]
 
 ## Issue description
 
-The kubelet is is leaking system logs via the `/logs` endpoint. This endoint is exposed as part of the kubelet's debug handlers.
+The kubelet is is leaking system logs via the `/logs` endpoint. This endpoint is exposed as part of the kubelet's debug handlers.
 
 ## Remediation
 


### PR DESCRIPTION
Fixing a typo in the knowledge base.