### PR TITLE
.travis.yml: Simplify and extract dev reqs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,19 @@
 group: travis_latest
 language: python
 cache: pip
-matrix:
-  include:
-    #- python: 3.4
-    #- python: 3.5
-    - python: 3.6
-    - python: 3.7
-      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-    #  sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+python:
+    #- "3.4"
+    #- "3.5"
+    - "3.6"
+    - "3.7"
 install:
   - pip install -r requirements.txt
-  - pip install flake8
+  - pip install -r requirements-dev.txt
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  - pip install pytest
 script:
   - python runtest.py
 notifications:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+flake8
+pytest


### PR DESCRIPTION
With Xenial being default, the yaml can be simplified.

Also extract requirements for development, so users can install it easily.