### PR TITLE
add .venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.venv
 .dockerignore
 *aqua*
 venv/


### PR DESCRIPTION
to support developers who use python virtual environment