### PR TITLE
job: Update the manifest to run as non-root

### DIFF
--- a/job.yaml
+++ b/job.yaml
@@ -7,8 +7,12 @@ spec:
     spec:
       containers:
       - name: kube-hunter
-        image: aquasec/kube-hunter 
+        image: aquasec/kube-hunter
         command: ["python", "kube-hunter.py"]
         args: ["--pod"]
       restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
   backoffLimit: 4


### PR DESCRIPTION
## Description

Currently the job has image which runs as root, hence if the cluster has
PSP which has following set:

```
  runAsUser:
    rule: MustRunAsNonRoot
```

The pod fails as following:

```
$ kubectl get pods
NAME                READY   STATUS                       RESTARTS   AGE
kube-hunter-fn2b9   0/1     CreateContainerConfigError   0          37s
```

This commit makes sure that the pod runs without such errors.

## Steps to reproduce the issue

Create following PSP: 

```yaml
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  annotations:
    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
  name: restricted
spec:
  allowPrivilegeEscalation: false
  fsGroup:
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
  requiredDropCapabilities:
  - KILL
  - MKNOD
  - SETUID
  - SETGID
  runAsUser:
    rule: MustRunAsNonRoot
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
  volumes:
  - configMap
  - emptyDir
  - projected
  - secret
  - downwardAPI
  - persistentVolumeClaim
```

Then in the repository run following command:

```bash
kubectl apply -f job.yaml
```


## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
