### PR TITLE
Remove __main__ references and create a top-level config module

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,6 @@
+# This module holds all the global.
+
+config = None
+def init(cfg):
+    global config
+    config = cfg

--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -20,8 +20,10 @@ parser.add_argument('--dispatch', type=str, default='stdout', help="where to sen
 parser.add_argument('--statistics', action="store_true", help="set hunting statistics")
 
 import plugins
+import conf
 
 config = parser.parse_args()
+conf.init(config)
 
 try:
     loglevel = getattr(logging, config.log.upper())
@@ -98,7 +100,6 @@ def list_hunters():
 global hunt_started_lock
 hunt_started_lock = threading.Lock()
 hunt_started = False
-
 
 def main():
     global hunt_started

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -5,7 +5,7 @@ This folder contains modules that will load before any parsing of arguments by k
 An example for using a plugin to add an argument:
 ```python
 # example.py
-from __main__ import parser
+from src.core.conf import config
 
 parser.add_argument('--exampleflag', action="store_true", help="enables active hunting")
 ```

--- a/runtest.py
+++ b/runtest.py
@@ -17,9 +17,11 @@ parser.add_argument('--statistics', action="store_true", help="set hunting stati
 
 config = parser.parse_args()
 
+import conf
 import tests
 
 def main():
+    conf.init(config)
     exit(pytest.main(['.']))
 
 

--- a/src/core/events/handler.py
+++ b/src/core/events/handler.py
@@ -5,13 +5,12 @@ from collections import defaultdict
 from queue import Queue
 from threading import Lock, Thread
 
-from __main__ import config
+from conf import config
 
 from ..types import ActiveHunter, Hunter, HunterBase
 
 from ...core.events.types import HuntFinished, Vulnerability, EventFilterBase
 import threading
-
 
 # Inherits Queue object, handles events asynchronously
 class EventQueue(Queue, object):

--- a/src/modules/discovery/hosts.py
+++ b/src/modules/discovery/hosts.py
@@ -9,7 +9,7 @@ from enum import Enum
 import requests
 from netaddr import IPNetwork, IPAddress
 
-from __main__ import config
+from conf import config
 from netifaces import AF_INET, ifaddresses, interfaces
 
 from ...core.events import handler

--- a/src/modules/hunting/cves.py
+++ b/src/modules/hunting/cves.py
@@ -2,7 +2,7 @@ import logging
 import json
 import requests
 
-from __main__ import config
+from conf import config
 
 from ...core.events import handler
 from ...core.events.types import Vulnerability, Event, K8sVersionDisclosure

--- a/src/modules/hunting/kubelet.py
+++ b/src/modules/hunting/kubelet.py
@@ -6,7 +6,7 @@ import re
 import requests
 import urllib3
 
-from __main__ import config
+from conf import config
 from ...core.events import handler
 from ...core.events.types import Vulnerability, Event, K8sVersionDisclosure
 from ..discovery.kubelet import ReadOnlyKubeletEvent, SecureKubeletEvent

--- a/src/modules/report/collector.py
+++ b/src/modules/report/collector.py
@@ -1,6 +1,6 @@
 import logging
 
-from __main__ import config
+from conf import config
 from src.core.events import handler
 from src.core.events.types import Event, Service, Vulnerability, HuntFinished, HuntStarted, ReportDispatched
 import threading

--- a/src/modules/report/dispatchers.py
+++ b/src/modules/report/dispatchers.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import requests
-from __main__ import config
+from conf import config
 
 
 class HTTPDispatcher(object):

--- a/src/modules/report/json_reporter.py
+++ b/src/modules/report/json_reporter.py
@@ -1,6 +1,6 @@
 import json
 from .base import BaseReporter
-from __main__ import config
+from conf import config
 
 class JSONReporter(BaseReporter):
     def get_report(self):

--- a/src/modules/report/plain.py
+++ b/src/modules/report/plain.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 from prettytable import ALL, PrettyTable
 
-from __main__ import config
+from conf import config
 from .collector import services, vulnerabilities, hunters, handler, services_lock, vulnerabilities_lock
 from .base import BaseReporter
 

--- a/src/modules/report/yaml.py
+++ b/src/modules/report/yaml.py
@@ -1,7 +1,7 @@
 from io import StringIO
 from ruamel.yaml import YAML
 from .base import BaseReporter
-from __main__ import config
+from conf import config
 
 class YAMLReporter(BaseReporter):
     def get_report(self):

--- a/tests/discovery/test_hosts.py
+++ b/tests/discovery/test_hosts.py
@@ -5,7 +5,7 @@ from queue import Empty
 from src.modules.discovery.hosts import FromPodHostDiscovery, RunningAsPodEvent, HostScanEvent, AzureMetadataApi
 from src.core.events.types import Event, NewHostEvent
 from src.core.events import handler
-from __main__ import config
+from conf import config
 
 def test_FromPodHostDiscovery():
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
It creates a top-level configuration module named `conf` which can be used without `__main__` reference, and reused throughout the application to provide the configuration.

It enables external profiling (memory profiling, CPU profiling for example), all scripts which have a different entry point than the kube-hunter script but still call it are now usable.

I didn't replace the `runtests.py` for now because I felt it was too much for a PR, this is simpler to grok right now, and when it feels appropriate, we could try to see how to replace directly the script with an good `pytest` call.

## Fixed Issues
Relates to #234 

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 
## Notes
I removed the stuff about automated testing because this change has no impact.
