### PR TITLE
Initial design for ExternalService API with service for public IP

### DIFF
--- a/src/modules/external_services/__init__.py
+++ b/src/modules/external_services/__init__.py
@@ -1,0 +1,2 @@
+from .exceptions import ExternalServiceFailure
+from .external_ip import ExternalIPService

--- a/src/modules/external_services/exceptions.py
+++ b/src/modules/external_services/exceptions.py
@@ -1,7 +1,15 @@
 class ExternalServiceFailure(Exception):
+    """
+    This exception can be thrown when a service action has failed (e.g. unable to determine any IP address, no cache result available when offline)
+    It is for user-code and external consumption of the service.
+    """
     def __init__(self):
         pass
 
 class ExternalProviderFailure(Exception):
+    """
+    This exception can be thrown when the provider of the service fails (e.g. the site is down, 400 error, etc.)
+    It is for internal consumption of external services which will decide to act upon a provider failure, by providing a cached result or throw a service failure.
+    """
     def __init__(self, exc=None):
         self.wrapped_exc = exc

--- a/src/modules/external_services/exceptions.py
+++ b/src/modules/external_services/exceptions.py
@@ -1,0 +1,7 @@
+class ExternalServiceFailure(Exception):
+    def __init__(self):
+        pass
+
+class ExternalProviderFailure(Exception):
+    def __init__(self, exc=None):
+        self.wrapped_exc = exc

--- a/src/modules/external_services/external_ip.py
+++ b/src/modules/external_services/external_ip.py
@@ -11,37 +11,41 @@ def generic_text_http_provider(url):
     except requests.ConnectionError as e:
         raise ExternalProviderFailure(e)
 
-ExtIPProvider = namedtuple('ExternalIPProvider', [
-    'handler',
+ExternalIPProvider = namedtuple('ExternalIPProvider', [
+    'provide', # provide the current address IP.
     'priority' # it means: secure, no logs, etc.
 ])
 
-CanHazIP = ExtIPProvider(handler=generic_text_http_provider('https://canhazip.com'), priority=0)
-Ipify = ExtIPProvider(handler=generic_text_http_provider('https://api.ipify.org'), priority=1)
+CanHazIP = ExternalIPProvider(provide=generic_text_http_provider('https://canhazip.com'), priority=0)
+Ipify = ExternalIPProvider(provide=generic_text_http_provider('https://api.ipify.org'), priority=1)
 
 DEFAULT_PROVIDERS = [CanHazIP, Ipify]
 
 class ExternalIPService:
     def __init__(self, providers=None, cache_results=True):
-        if providers and not all(isinstance(i, ExtIPProvider) for i in providers):
+        if providers and not all(isinstance(i, ExternalIPProvider) for i in providers):
             raise TypeError('A provider must be of type `ExternalIPProvider`!')
-        
+
         # Order provider by priority
         self.providers = sorted(providers or DEFAULT_PROVIDERS, key=lambda provider: provider.priority, reverse=True)
         self.cache_results = cache_results
+        self.cached_ip = None
 
-    def try_get(self, bypass_cache=False):
-        if not bypass_cache and self.cache_results and self.cached_ip:
+    def try_get(self, use_cache=True):
+        if use_cache and self.cache_results and self.cached_ip:
             return self.cached_ip
-        
+
         last_exc = None
         for provider in self.providers:
             try:
-                ip = provider.handler()
-                self.cached_ip = ip
+                ip = provider.provide()
+
+                if self.cache_results:
+                    self.cached_ip = ip
+
                 return ip
             except ExternalProviderFailure as exc:
                 last_exc = exc
-        
+
         # Tough luck.
         raise ExternalServiceFailure(exc=last_exc)

--- a/src/modules/external_services/external_ip.py
+++ b/src/modules/external_services/external_ip.py
@@ -1,7 +1,9 @@
-from .exceptions import ExternalServiceFailure, ExternalProviderFailure
+from collections import namedtuple
 
 import requests
-from collections import namedtuple
+
+from .exceptions import ExternalProviderFailure, ExternalServiceFailure
+
 
 def generic_text_http_provider(url):
     try:

--- a/src/modules/external_services/external_ip.py
+++ b/src/modules/external_services/external_ip.py
@@ -1,0 +1,45 @@
+from .exceptions import ExternalServiceFailure, ExternalProviderFailure
+
+import requests
+from collections import namedtuple
+
+def generic_text_http_provider(url):
+    try:
+        return requests.get(url).text
+    except requests.ConnectionError as e:
+        raise ExternalProviderFailure(e)
+
+ExtIPProvider = namedtuple('ExternalIPProvider', [
+    'handler',
+    'priority' # it means: secure, no logs, etc.
+])
+
+CanHazIP = ExtIPProvider(handler=generic_text_http_provider('https://canhazip.com'), priority=0)
+Ipify = ExtIPProvider(handler=generic_text_http_provider('https://api.ipify.org'), priority=1)
+
+DEFAULT_PROVIDERS = [CanHazIP, Ipify]
+
+class ExternalIPService:
+    def __init__(self, providers=None, cache_results=True):
+        if providers and not all(isinstance(i, ExtIPProvider) for i in providers):
+            raise TypeError('A provider must be of type `ExternalIPProvider`!')
+        
+        # Order provider by priority
+        self.providers = sorted(providers or DEFAULT_PROVIDERS, key=lambda provider: provider.priority, reverse=True)
+        self.cache_results = cache_results
+
+    def try_get(self, bypass_cache=False):
+        if not bypass_cache and self.cache_results and self.cached_ip:
+            return self.cached_ip
+        
+        last_exc = None
+        for provider in self.providers:
+            try:
+                ip = provider.handler()
+                self.cached_ip = ip
+                return ip
+            except ExternalProviderFailure as exc:
+                last_exc = exc
+        
+        # Tough luck.
+        raise ExternalServiceFailure(exc=last_exc)


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
As per to #235 ; I'm trying to see what kind of external service API would fit the usage in Kube Hunter (as in, it's generalizable for other external services).
Here is an initial idea, I didn't want to go full OO magic, using singletons pattern & whatever.

This is a very simple PR, though it has the potential for external plugins to use their own providers of public IP, it can be used to modify if you want IPv4/IPv6, it can accommodate special use cases: when you want *private* IP, let's say, you're in a private VPC or something like this.

Two things are left as questions and require feedback:

- Test, how do we want to go? I can test for generic failures using mock and ensure that `try_get` calls the second provider. That's a simple enough and relevant test to do. But before, I want to know if that'd be interesting to move this logic into a base class called `ServiceWithFailover` which enables this pattern.
- Propagate a form of configuration to the modules, if we want to globally use only this provider, we may want that all subsequent instances of ExternalService instantiates using only those specific providers, what I usually suggest is to use module name which are importable: `["plugins.external_providers.canhazip", "plugins.external_providers.ipify"]` for example, this can be configured in some file or even in the `conf.py` if #264 is merged.

This enables new patterns to configure stuff using environment variables too. Anyway, I need feedback to understand what maintainers feel is the most appropriate for this project.

Bonus: Ipify.org is added.

## Fixed Issues

Fixes #235 

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
As above-mentioned, automated testing is a question.
