### PR TITLE
Support macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 enum34 ; python_version<='3.4'
 netaddr
 netifaces
-scapy==2.4.3rc1
+scapy>=2.4.3
 requests
 PrettyTable
 urllib3>=1.24.2,<1.25


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Upgrade scapy to version 2.4.3 and above.
This commit fixes IndexError that was raised when running
kube-hunter from macOS.

## Contribution Guidelines
:white_check_mark:

## Fixed Issues

Fixes #262 

## "BEFORE" and "AFTER" output

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Need to add CI test on multiple operating systems, out of this PR scope.
