### PR TITLE
fixex 404 kb href 

### DIFF
--- a/src/modules/report/plain.py
+++ b/src/modules/report/plain.py
@@ -8,7 +8,7 @@ from .base import BaseReporter
 
 EVIDENCE_PREVIEW = 40
 MAX_TABLE_WIDTH = 20
-KB_LINK = "https://github.com/aquasecurity/kube-hunter/tree/master/docs/kb"
+KB_LINK = "https://github.com/aquasecurity/kube-hunter/tree/master/docs/_kb"
 
 
 class PlainReporter(BaseReporter):


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Fixes 404 href link to kb index

### BEFORE
For further information about a vulnerability, search its ID in:
https://github.com/aquasecurity/kube-hunter/tree/master/docs/kb

### AFTER
For further information about a vulnerability, search its ID in:
https://github.com/aquasecurity/kube-hunter/tree/master/docs/_kb
