### PR TITLE
kube_hunter/modules/discovery/apiserver.py: add discovery timeout

### DIFF
--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -14,6 +14,7 @@ parser.add_argument('--log', type=str, metavar="LOGLEVEL", default='INFO', help=
 parser.add_argument('--report', type=str, default='plain', help="set report type, options are: plain, yaml, json")
 parser.add_argument('--dispatch', type=str, default='stdout', help="where to send the report to, options are: stdout, http (set KUBEHUNTER_HTTP_DISPATCH_URL and KUBEHUNTER_HTTP_DISPATCH_METHOD environment variables to configure)")
 parser.add_argument('--statistics', action="store_true", help="set hunting statistics")
+parser.add_argument('--discovery-timeout', type=int, default=5, help="kube-apiserver discovery timeout")
 
 import plugins
 

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -6,6 +6,8 @@ from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import OpenPortEvent, Service, Event, EventFilterBase
 
+from kube_hunter.conf import config
+
 KNOWN_API_PORTS = [443, 6443, 8080]
 
 class K8sApiService(Service, Event):
@@ -49,7 +51,7 @@ class ApiServiceDiscovery(Discovery):
 
     def has_api_behaviour(self, protocol):
         try:
-            r = self.session.get("{}://{}:{}".format(protocol, self.event.host, self.event.port), timeout=30)
+            r = self.session.get("{}://{}:{}".format(protocol, self.event.host, self.event.port), timeout=config.discovery_timeout)
             if ('k8s' in r.text) or ('"code"' in r.text and r.status_code != 200):
                 return True
         except requests.exceptions.SSLError:

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -49,7 +49,7 @@ class ApiServiceDiscovery(Discovery):
 
     def has_api_behaviour(self, protocol):
         try:
-            r = self.session.get("{}://{}:{}".format(protocol, self.event.host, self.event.port))
+            r = self.session.get("{}://{}:{}".format(protocol, self.event.host, self.event.port), timeout=30)
             if ('k8s' in r.text) or ('"code"' in r.text and r.status_code != 200):
                 return True
         except requests.exceptions.SSLError:


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
When probing kube-apiserver, timeout if connection couldn't be open
after 30 seconds or if kube-apiserver didn't respond within 30 seconds.

This prevents kube-hunter from running for long time, when you hit
slowly responding server during the discovery.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues

Please mention any issues fixed in the PR by referencing it properly in the commit message.
As per the convention, use appropriate keywords such as `fixes`, `closes`, `resolves` to automatically refer the issue.
Please consult [official github documentation](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) for details.

Fixes #35 

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>
