### PR TITLE
Support ignoring IPs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=builder /kube-hunter /kube-hunter
 
 WORKDIR /kube-hunter
 
-ENTRYPOINT ["python",  "kube-hunter.py"]
+ENTRYPOINT ["python", "-u",  "kube-hunter.py"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ To specify interface scanning, you can use the `--interface` option (this will s
 To specify a specific CIDR to scan, use the `--cidr` option. Example:
 `./kube-hunter.py --cidr 192.168.0.0/24`
 
+IPs can be ignored from a CIDR range by using the `--ignore` flag. It supports multiple values by separating with a comma.
+
 ### Active Hunting
 
 Active hunting is an option in which kube-hunter will exploit vulnerabilities it finds, to explore for further vulnerabilities.

--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -4,6 +4,8 @@ import argparse
 import logging
 import threading
 
+from netaddr import IPAddress
+
 from kube_hunter.conf import config
 from kube_hunter.modules.report.plain import PlainReporter
 from kube_hunter.modules.report.yaml import YAMLReporter
@@ -41,6 +43,12 @@ if config.dispatch.lower() in dispatchers.keys():
 else:
     logging.warning('Unknown dispatcher selected, using stdout')
     config.dispatcher = dispatchers['stdout']()
+
+if config.ignore:
+    ips = []
+    for ip in config.ignore.split(','):
+        ips.append(IPAddress(ip))
+    config.ignore = ips
 
 import kube_hunter
 

--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -6,7 +6,7 @@ parser.add_argument('--interface', action="store_true", help="set hunting of all
 parser.add_argument('--pod', action="store_true", help="set hunter as an insider pod")
 parser.add_argument('--quick', action="store_true", help="Prefer quick scan (subnet 24)")
 parser.add_argument('--include-patched-versions', action="store_true", help="Don't skip patched versions when scanning")
-parser.add_argument('--cidr', type=str, help="set an ip range to scan, example: 192.168.0.0/16")
+parser.add_argument('--cidr', type=str, help="set an IP range to scan, example: 192.168.0.0/16")
 parser.add_argument('--mapping', action="store_true", help="outputs only a mapping of the cluster's nodes")
 parser.add_argument('--remote', nargs='+', metavar="HOST", default=list(), help="one or more remote ip/dns to hunt")
 parser.add_argument('--active', action="store_true", help="enables active hunting")
@@ -14,6 +14,7 @@ parser.add_argument('--log', type=str, metavar="LOGLEVEL", default='INFO', help=
 parser.add_argument('--report', type=str, default='plain', help="set report type, options are: plain, yaml, json")
 parser.add_argument('--dispatch', type=str, default='stdout', help="where to send the report to, options are: stdout, http (set KUBEHUNTER_HTTP_DISPATCH_URL and KUBEHUNTER_HTTP_DISPATCH_METHOD environment variables to configure)")
 parser.add_argument('--statistics', action="store_true", help="set hunting statistics")
+parser.add_argument('--ignore', type=str, help="set IP(s) to ignore, example: 192.168.1.8,192.168.1.3")
 
 import plugins
 

--- a/kube_hunter/modules/discovery/hosts.py
+++ b/kube_hunter/modules/discovery/hosts.py
@@ -73,6 +73,9 @@ class HostDiscoveryHelpers:
         logging.debug("HostDiscoveryHelpers.generate_subnet {0}/{1}".format(ip, sn))
         subnet = IPNetwork('{ip}/{sn}'.format(ip=ip, sn=sn))
         for ip in IPNetwork(subnet):
+            if config.ignore and ip in config.ignore:
+                logging.debug("HostDiscoveryHelpers.generate_subnet ignoring {0}".format(ip))
+                continue
             logging.debug("HostDiscoveryHelpers.generate_subnet yielding {0}".format(ip))
             yield ip
 


### PR DESCRIPTION
Signed-off-by: Dustin Decker <dustin.decker@getcruise.com>

Closes #296 

## Description
Added support for ignoring IPs that are enumerated from a CIDR range with a `--ignore` flag.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues

Fixes #296

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

### BEFORE
Any Terminal Output Before Changes.

### AFTER
```
python3 kube-hunter.py --cidr 10.20.111.105/32 --ignore 10.20.111.105
Kube Hunter couldn't find any clusters
```

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [] I have added automated testing to cover this case.
 
## Notes
I did not add any tests for this feature.
