### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+NAME := kube-hunter
+SRC  := kube_hunter
+
+.PHONY: deps
+deps:
+	pip install -r requirements-dev.txt
+
+.PHONY: lint
+lint:
+	flake8 $(SRC)
+
+.PHONY: build
+build:
+	python setup.py sdist bdist_wheel
+
+.PHONY: install
+install:
+	pip install -e .
+
+.PHONY: uninstall
+uninstall:
+	pip uninstall $(NAME)
+
+.PHONY: publish
+publish:
+	twine upload dist/*
+
+.PHONY: clean
+clean:
+	rm -rf build/ dist/ *.egg-info/ .eggs/ .pytest_cache/ .coverage
+	find . -type d -name __pycache__ -exec rm -rf '{}' +


### PR DESCRIPTION
Added Makefile with some helpful utils such as build, lint and clean.

<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Add Makefile for development convenience and simplify frequently used actions.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues
None

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
This is commit adds no functionality and therefore, no tests are needed.
