### PR TITLE
Add PyInstaller build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.spec
+.eggs
 
 # Directory Cache Files
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ deps:
 lint:
 	flake8 $(SRC)
 
+.PHONY: test
+test:
+	pytest
+
 .PHONY: build
 build:
 	python setup.py sdist bdist_wheel

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
-NAME := kube-hunter
-SRC  := kube_hunter
+.SILENT:
+
+NAME            := kube-hunter
+SRC             := kube_hunter
+ENTRYPOINT      := $(SRC)/__main__.py
+DIST            := dist
+COMPILED        := $(DIST)/$(NAME)
+STATIC_COMPILED := $(COMPILED).static
+
 
 .PHONY: deps
 deps:
@@ -13,9 +20,21 @@ lint:
 build:
 	python setup.py sdist bdist_wheel
 
+.PHONY: pyinstaller
+pyinstaller: deps
+	python setup.py pyinstaller
+
+.PHONY: staticx_deps
+staticx_deps:
+	command -v patchelf > /dev/null 2>&1 || (echo "patchelf is not available. install it in order to use staticx" && false)
+
+.PHONY: pyinstaller_static
+pyinstaller_static: staticx_deps pyinstaller
+	staticx $(COMPILED) $(STATIC_COMPILED)
+
 .PHONY: install
 install:
-	pip install -e .
+	pip install .
 
 .PHONY: uninstall
 uninstall:
@@ -27,5 +46,5 @@ publish:
 
 .PHONY: clean
 clean:
-	rm -rf build/ dist/ *.egg-info/ .eggs/ .pytest_cache/ .coverage
+	rm -rf build/ dist/ *.egg-info/ .eggs/ .pytest_cache/ .coverage *.spec
 	find . -type d -name __pycache__ -exec rm -rf '{}' +

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,5 @@ pytest-cov
 setuptools >= 30.3.0
 setuptools_scm
 twine
+pyinstaller
+staticx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 
 flake8
 pytest >= 2.9.1
+requests-mock
 coverage < 5.0
 pytest-cov
 setuptools >= 30.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     PrettyTable
     urllib3>=1.24.2,<1.25
     ruamel.yaml
-    requests_mock
     future
     packaging
 setup_requires =
@@ -45,6 +44,7 @@ test_requires =
     pytest>=2.9.1
     coverage<5.0
     pytest-cov
+    requests-mock
 python_requires = >=3.6
 
 [options.entry_points]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,41 @@
-from setuptools import setup
+from subprocess import check_call
+from pkg_resources import parse_requirements
+from configparser import ConfigParser
+from setuptools import setup, Command
+
+
+class PyInstallerCommand(Command):
+    """A custom command to run PyInstaller to build standalone executable."""
+
+    description = "run PyInstaller on kube-hunter entrypoint"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        cfg = ConfigParser()
+        cfg.read("setup.cfg")
+        command = [
+            "pyinstaller",
+            "--clean",
+            "--onefile",
+            "--name",
+            "kube-hunter",
+        ]
+        setup_cfg = cfg["options"]["install_requires"]
+        requirements = parse_requirements(setup_cfg)
+        for r in requirements:
+            command.extend(["--hidden-import", r.key])
+        command.append("kube_hunter/__main__.py")
+        print(' '.join(command))
+        check_call(command)
+
 
 setup(
     use_scm_version=True,
+    cmdclass={"pyinstaller": PyInstallerCommand},
 )


### PR DESCRIPTION
## Description
Add standard method for building with PyInstaller.
Use staticx to generate a single static binary.
PyInstaller and staticx builds given as Makefile targets `pyinstaller` and `pyinstaller_static` accordingly.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues
Resolves #301

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
No functionality added, therefore, there's nothing to cover with tests.
