### PR TITLE
Fix broken logging

### DIFF
--- a/kube_hunter/__init__.py
+++ b/kube_hunter/__init__.py
@@ -1,2 +1,0 @@
-from . import core
-from . import modules

--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -5,6 +5,12 @@ import logging
 import threading
 
 from kube_hunter.conf import config
+
+loglevel = getattr(logging, config.log.upper(), logging.INFO)
+
+if config.log.lower() != "none":
+    logging.basicConfig(level=loglevel, format='%(message)s', datefmt='%H:%M:%S')
+
 from kube_hunter.modules.report.plain import PlainReporter
 from kube_hunter.modules.report.yaml import YAMLReporter
 from kube_hunter.modules.report.json import JSONReporter
@@ -12,12 +18,6 @@ from kube_hunter.modules.report.dispatchers import STDOUTDispatcher, HTTPDispatc
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import HuntFinished, HuntStarted
 from kube_hunter.modules.discovery.hosts import RunningAsPodEvent, HostScanEvent
-
-
-loglevel = getattr(logging, config.log.upper(), logging.INFO)
-
-if config.log.lower() != "none":
-    logging.basicConfig(level=loglevel, format='%(message)s', datefmt='%H:%M:%S')
 
 reporters = {
     'yaml': YAMLReporter,

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -1,0 +1,29 @@
+from kube_hunter.core.types import HunterBase
+
+
+def test_parse_docs_empty():
+    expected = ("kube_hunter.core.types", "<no documentation>")
+    actual = HunterBase.parse_docs("")
+    assert actual == expected
+
+
+def test_parse_docs_only_header():
+    docs = "SomeHunter"
+    expected = ("SomeHunter", "<no documentation>")
+    actual = HunterBase.parse_docs(docs)
+    assert actual == expected
+
+
+def test_parse_docs_with_body():
+    docs = "SomeHunter\n Very \n interesting hunter. "
+    expected = ("SomeHunter", "Very interesting hunter.")
+    actual = HunterBase.parse_docs(docs)
+    assert actual == expected
+
+
+def test_hunter_base_get_name():
+    class SomeHunter(HunterBase):
+        """SomeHunter
+        This is a test hunter
+        """
+    assert SomeHunter.get_name() == "SomeHunter"


### PR DESCRIPTION
## Description
Remove unnecessary imports from `kube_hunter/__init__.py` that cause
hook registration before main file execution.
This made the event loop handler indirectly configure the root logger,
which in turn prevented the main file configuring it with user parameters.

I opened #308 for further work in this subject.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues

Fixes #292

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

### BEFORE
Running kube-hunter would not print log messages, no matter what `--log` parameter is set.

### AFTER
Running kube-hunter sets log level to `--log` parameter.

## Contribution checklist
 - [X] I have read the Contributing Guidelines.
 - [X] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Tested it manually. Integration tests need to be created to automatically test it.
