### PR TITLE
Network operations timeout

### DIFF
--- a/kube_hunter/conf/parser.py
+++ b/kube_hunter/conf/parser.py
@@ -80,9 +80,9 @@ def parse_args():
         help="Show hunting statistics")
 
     parser.add_argument(
-        '--discovery-timeout',
+        '--network-timeout',
         type=float,
         default=5.0,
-        help="discovery network operations timeout")
+        help="network operations timeout")
 
     return parser.parse_args()

--- a/kube_hunter/conf/parser.py
+++ b/kube_hunter/conf/parser.py
@@ -79,4 +79,10 @@ def parse_args():
         action="store_true",
         help="Show hunting statistics")
 
+    parser.add_argument(
+        '--discovery-timeout',
+        type=float,
+        default=5.0,
+        help="discovery network operations timeout")
+
     return parser.parse_args()

--- a/kube_hunter/core/events/types/common.py
+++ b/kube_hunter/core/events/types/common.py
@@ -157,10 +157,17 @@ class ReportDispatched(Event):
 
 
 """ Core Vulnerabilities """
+
+
 class K8sVersionDisclosure(Vulnerability, Event):
     """The kubernetes version could be obtained from the {} endpoint """
     def __init__(self, version, from_endpoint, extra_info=""):
-        Vulnerability.__init__(self, KubernetesCluster, "K8s Version Disclosure", category=InformationDisclosure, vid="KHV002")
+        Vulnerability.__init__(
+            self,
+            KubernetesCluster,
+            "K8s Version Disclosure",
+            category=InformationDisclosure,
+            vid="KHV002")
         self.version = version
         self.from_endpoint = from_endpoint
         self.extra_info = extra_info

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -6,6 +6,8 @@ from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import OpenPortEvent, Service, Event, EventFilterBase
 
+from kube_hunter.conf import config
+
 KNOWN_API_PORTS = [443, 6443, 8080]
 
 class K8sApiService(Service, Event):
@@ -49,7 +51,7 @@ class ApiServiceDiscovery(Discovery):
 
     def has_api_behaviour(self, protocol):
         try:
-            r = self.session.get("{}://{}:{}".format(protocol, self.event.host, self.event.port), timeout=30)
+            r = self.session.get("{}://{}:{}".format(protocol, self.event.host, self.event.port), timeout=config.discovery_timeout)
             if ('k8s' in r.text) or ('"code"' in r.text and r.status_code != 200):
                 return True
         except requests.exceptions.SSLError:

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -49,7 +49,7 @@ class ApiServiceDiscovery(Discovery):
 
     def has_api_behaviour(self, protocol):
         try:
-            r = self.session.get("{}://{}:{}".format(protocol, self.event.host, self.event.port))
+            r = self.session.get("{}://{}:{}".format(protocol, self.event.host, self.event.port), timeout=30)
             if ('k8s' in r.text) or ('"code"' in r.text and r.status_code != 200):
                 return True
         except requests.exceptions.SSLError:

--- a/kube_hunter/modules/discovery/dashboard.py
+++ b/kube_hunter/modules/discovery/dashboard.py
@@ -3,6 +3,7 @@ import logging
 
 import requests
 
+from kube_hunter.conf import config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, OpenPortEvent, Service
 from kube_hunter.core.types import Discovery
@@ -12,6 +13,7 @@ class KubeDashboardEvent(Service, Event):
     """A web-based Kubernetes user interface. allows easy usage with operations on the cluster"""
     def __init__(self, **kargs):
         Service.__init__(self, name="Kubernetes Dashboard", **kargs)
+
 
 @handler.subscribe(OpenPortEvent, predicate=lambda x: x.port == 30000)
 class KubeDashboard(Discovery):
@@ -23,10 +25,14 @@ class KubeDashboard(Discovery):
 
     @property
     def secure(self):
+        endpoint = f"http://{self.event.host}:{self.event.port}/api/v1/service/default"
         logging.debug("Attempting to discover an Api server to access dashboard")
-        r = requests.get("http://{}:{}/api/v1/service/default".format(self.event.host, self.event.port))
-        if "listMeta" in r.text and len(json.loads(r.text)["errors"]) == 0:
-            return False
+        try:
+            r = requests.get(endpoint, timeout=config.network_timeout)
+            if "listMeta" in r.text and len(json.loads(r.text)["errors"]) == 0:
+                return False
+        except requests.Timeout:
+            logging.debug(f"failed getting {endpoint}", exc_info=True)
         return True
 
     def execute(self):

--- a/kube_hunter/modules/discovery/hosts.py
+++ b/kube_hunter/modules/discovery/hosts.py
@@ -174,7 +174,8 @@ class HostDiscovery(Discovery):
     def scan_interfaces(self):
         try:
             logging.debug("HostDiscovery hunter attempting to get external IP address")
-            external_ip = requests.get("https://canhazip.com", timeout=network_timeout).text # getting external ip, to determine if cloud cluster
+            # getting external ip, to determine if cloud cluster
+            external_ip = requests.get("https://canhazip.com", timeout=config.network_timeout).text
         except requests.ConnectionError as e:
             logging.debug("unable to determine local IP address: {0}".format(e))
             logging.info("~ default to 127.0.0.1")

--- a/kube_hunter/modules/hunting/aks.py
+++ b/kube_hunter/modules/hunting/aks.py
@@ -3,6 +3,7 @@ import logging
 
 import requests
 
+from kube_hunter.conf import config
 from kube_hunter.modules.hunting.kubelet import ExposedRunHandler
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, Vulnerability
@@ -15,21 +16,26 @@ class AzureSpnExposure(Vulnerability, Event):
         Vulnerability.__init__(self, Azure, "Azure SPN Exposure", category=IdentityTheft, vid="KHV004")
         self.container = container
 
-@handler.subscribe(ExposedRunHandler, predicate=lambda x: x.cloud=="Azure")
+
+@handler.subscribe(ExposedRunHandler, predicate=lambda x: x.cloud == "Azure")
 class AzureSpnHunter(Hunter):
     """AKS Hunting
     Hunting Azure cluster deployments using specific known configurations
     """
     def __init__(self, event):
         self.event = event
-        self.base_url = "https://{}:{}".format(self.event.host, self.event.port)
+        self.base_url = f"https://{self.event.host}:{self.event.port}"
 
     # getting a container that has access to the azure.json file
     def get_key_container(self):
+        endpoint = f"{self.base_url}/pods"
         logging.debug("Passive Hunter is attempting to find container with access to azure.json file")
-        raw_pods = requests.get(self.base_url + "/pods", verify=False).text
-        if "items" in raw_pods:
-            pods_data = json.loads(raw_pods)["items"]
+        try:
+            r = requests.get(endpoint, verify=False, timeout=config.network_timeout)
+        except requests.Timeout:
+            logging.debug("failed getting pod info")
+        else:
+            pods_data = r.json().get("items", [])
             for pod_data in pods_data:
                 for container in pod_data["spec"]["containers"]:
                     for mount in container["volumeMounts"]:
@@ -46,6 +52,7 @@ class AzureSpnHunter(Hunter):
         if container:
             self.publish_event(AzureSpnExposure(container=container))
 
+
 """ Active Hunting """
 @handler.subscribe(AzureSpnExposure)
 class ProveAzureSpnExposure(ActiveHunter):
@@ -54,23 +61,31 @@ class ProveAzureSpnExposure(ActiveHunter):
     """
     def __init__(self, event):
         self.event = event
-        self.base_url = "https://{}:{}".format(self.event.host, self.event.port)
+        self.base_url = f"https://{self.event.host}:{self.event.port}"
 
     def run(self, command, container):
-        run_url = "{base}/run/{pod_namespace}/{pod_id}/{container_name}".format(
-            base=self.base_url,
-            pod_namespace=container["namespace"],
-            pod_id=container["pod"],
-            container_name=container["name"]
-        )
-        return requests.post(run_url, verify=False, params={'cmd': command}).text
+        run_url = "/".join(
+            self.base_url,
+            "run",
+            container["namespace"],
+            container["pod"],
+            container["name"])
+        return requests.post(
+            run_url,
+            verify=False,
+            params={'cmd': command},
+            timeout=config.network_timeout)
 
     def execute(self):
-        raw_output = self.run("cat /etc/kubernetes/azure.json", container=self.event.container)
-        if "subscriptionId" in raw_output:
-            subscription = json.loads(raw_output)
-            self.event.subscriptionId = subscription["subscriptionId"]
-            self.event.aadClientId = subscription["aadClientId"]
-            self.event.aadClientSecret = subscription["aadClientSecret"]
-            self.event.tenantId = subscription["tenantId"]
-            self.event.evidence = "subscription: {}".format(self.event.subscriptionId)
+        try:
+            r = self.run("cat /etc/kubernetes/azure.json", container=self.event.container)
+        except requests.Timeout:
+            logging.debug("failed to run command in container", exc_info=True)
+        else:
+            subscription = r.json()
+            if "subscriptionId" in subscription:
+                self.event.subscriptionId = subscription["subscriptionId"]
+                self.event.aadClientId = subscription["aadClientId"]
+                self.event.aadClientSecret = subscription["aadClientSecret"]
+                self.event.tenantId = subscription["tenantId"]
+                self.event.evidence = f"subscription: {self.event.subscriptionId}"

--- a/kube_hunter/modules/hunting/apiserver.py
+++ b/kube_hunter/modules/hunting/apiserver.py
@@ -2,18 +2,18 @@ import logging
 import json
 import requests
 import uuid
-import copy
 
+from kube_hunter.conf import config
 from kube_hunter.modules.discovery.apiserver import ApiServer
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Vulnerability, Event, K8sVersionDisclosure
 from kube_hunter.core.types import Hunter, ActiveHunter, KubernetesCluster
-from kube_hunter.core.types import RemoteCodeExec, AccessRisk, InformationDisclosure, UnauthenticatedAccess
+from kube_hunter.core.types import AccessRisk, InformationDisclosure, UnauthenticatedAccess
 
 
 class ServerApiAccess(Vulnerability, Event):
-    """ The API Server port is accessible. Depending on your RBAC settings this could expose access to or control of your cluster. """
-
+    """The API Server port is accessible.
+    Depending on your RBAC settings this could expose access to or control of your cluster."""
     def __init__(self, evidence, using_token):
         if using_token:
             name = "Access to API using service account token"
@@ -24,23 +24,26 @@ class ServerApiAccess(Vulnerability, Event):
         Vulnerability.__init__(self, KubernetesCluster, name=name, category=category, vid="KHV005")
         self.evidence = evidence
 
-class ServerApiHTTPAccess(Vulnerability, Event):
-    """ The API Server port is accessible over HTTP, and therefore unencrypted. Depending on your RBAC settings this could expose access to or control of your cluster. """
 
+class ServerApiHTTPAccess(Vulnerability, Event):
+    """The API Server port is accessible over HTTP, and therefore unencrypted.
+    Depending on your RBAC settings this could expose access to or control of your cluster."""
     def __init__(self, evidence):
         name = "Insecure (HTTP) access to API"
         category = UnauthenticatedAccess
         Vulnerability.__init__(self, KubernetesCluster, name=name, category=category, vid="KHV006")
         self.evidence = evidence
 
+
 class ApiInfoDisclosure(Vulnerability, Event):
     def __init__(self, evidence, using_token, name):
         if using_token:
-            name +=" using service account token"
+            name += " using service account token"
         else:
-            name +=" as anonymous user"
+            name += " as anonymous user"
         Vulnerability.__init__(self, KubernetesCluster, name=name, category=InformationDisclosure, vid="KHV007")
         self.evidence = evidence
+
 
 class ListPodsAndNamespaces(ApiInfoDisclosure):
     """ Accessing pods might give an attacker valuable information"""
@@ -202,15 +205,19 @@ class AccessApiServer(Hunter):
 
     def __init__(self, event):
         self.event = event
-        self.path = "{}://{}:{}".format(self.event.protocol, self.event.host, self.event.port)
+        self.path = f"{self.event.protocol}://{self.event.host}:{self.event.port}"
         self.headers = {}
         self.with_token = False
 
     def access_api_server(self):
-        logging.debug('Passive Hunter is attempting to access the API at {}'.format(self.path))
+        logging.debug(f"Passive Hunter is attempting to access the API at {self.path}")
         try:
-            r = requests.get("{path}/api".format(path=self.path), headers=self.headers, verify=False)
-            if r.status_code == 200 and r.content != '':
+            r = requests.get(
+                f"{self.path}/api",
+                headers=self.headers,
+                verify=False,
+                timeout=config.network_timeout)
+            if r.status_code == 200 and r.content:
                 return r.content
         except requests.exceptions.ConnectionError:
             pass
@@ -219,8 +226,8 @@ class AccessApiServer(Hunter):
     def get_items(self, path):
         try:
             items = []
-            r = requests.get(path, headers=self.headers, verify=False)
-            if r.status_code ==200:
+            r = requests.get(path, headers=self.headers, verify=False, timeout=config.network_timeout)
+            if r.status_code == 200:
                 resp = json.loads(r.content)
                 for item in resp["items"]:
                     items.append(item["metadata"]["name"])
@@ -234,19 +241,24 @@ class AccessApiServer(Hunter):
     def get_pods(self, namespace=None):
         pods = []
         try:
-            if namespace is None:
-                r = requests.get("{path}/api/v1/pods".format(path=self.path),
-                               headers=self.headers, verify=False)
+            if not namespace:
+                r = requests.get(
+                    f"{self.path}/api/v1/pods",
+                    headers=self.headers,
+                    verify=False,
+                    timeout=config.network_timeout)
             else:
-                r = requests.get("{path}/api/v1/namespaces/{namespace}/pods".format(path=self.path),
-                               headers=self.headers, verify=False)
+                r = requests.get(
+                    f"{self.path}/api/v1/namespaces/{namespace}/pods",
+                    headers=self.headers,
+                    verify=False,
+                    timeout=config.network_timeout)
             if r.status_code == 200:
                 resp = json.loads(r.content)
                 for item in resp["items"]:
-                    name = item["metadata"]["name"].encode('ascii', 'ignore')
-                    namespace = item["metadata"]["namespace"].encode('ascii', 'ignore')
-                    pods.append({'name': name, 'namespace': namespace})
-
+                    name = item["metadata"]["name"].encode("ascii", "ignore")
+                    namespace = item["metadata"]["namespace"].encode("ascii", "ignore")
+                    pods.append({"name": name, "namespace": namespace})
                 return pods
         except (requests.exceptions.ConnectionError, KeyError):
             pass
@@ -280,6 +292,7 @@ class AccessApiServer(Hunter):
         # the token
         self.publish_event(ApiServerPassiveHunterFinished(namespaces))
 
+
 @handler.subscribe(ApiServer, predicate=lambda x: x.auth_token)
 class AccessApiServerWithToken(AccessApiServer):
     """ API Server Hunter
@@ -288,8 +301,8 @@ class AccessApiServerWithToken(AccessApiServer):
 
     def __init__(self, event):
         super(AccessApiServerWithToken, self).__init__(event)
-        assert self.event.auth_token != ''
-        self.headers = {'Authorization': 'Bearer ' + self.event.auth_token}
+        assert self.event.auth_token
+        self.headers = {"Authorization": f"Bearer {self.event.auth_token}"}
         self.category = InformationDisclosure
         self.with_token = True
 
@@ -303,37 +316,42 @@ class AccessApiServerActive(ActiveHunter):
 
     def __init__(self, event):
         self.event = event
-        self.path = "{}://{}:{}".format(self.event.protocol, self.event.host, self.event.port)
+        self.path = f"{self.event.protocol}://{self.event.host}:{self.event.port}"
 
-    def create_item(self, path, name, data):
+    def create_item(self, path, data):
         headers = {
-            'Content-Type': 'application/json'
+            "Content-Type": "application/json"
         }
         if self.event.auth_token:
-            headers['Authorization'] = 'Bearer {token}'.format(token=self.event.auth_token)
+            headers["Authorization"] = f"Bearer {self.event.auth_token}"
 
         try:
-            res = requests.post(path.format(name=name), verify=False, data=data, headers=headers)
+            res = requests.post(
+                path,
+                verify=False,
+                data=data,
+                headers=headers,
+                timeout=config.network_timeout)
             if res.status_code in [200, 201, 202]:
                 parsed_content = json.loads(res.content)
-                return parsed_content['metadata']['name']
+                return parsed_content["metadata"]["name"]
         except (requests.exceptions.ConnectionError, KeyError):
             pass
         return None
 
     def patch_item(self, path, data):
         headers = {
-            'Content-Type': 'application/json-patch+json'
+            "Content-Type": "application/json-patch+json"
         }
         if self.event.auth_token:
-            headers['Authorization'] = 'Bearer {token}'.format(token=self.event.auth_token)
+            headers["Authorization"] = f"Bearer {self.event.auth_token}"
         try:
-            res = requests.patch(path, headers=headers, verify=False, data=data)
+            res = requests.patch(path, headers=headers, verify=False, data=data, timeout=config.network_timeout)
             if res.status_code not in [200, 201, 202]:
                 return None
             parsed_content = json.loads(res.content)
             # TODO is there a patch timestamp we could use?
-            return parsed_content['metadata']['namespace']
+            return parsed_content["metadata"]["namespace"]
         except (requests.exceptions.ConnectionError, KeyError):
             pass
         return None
@@ -341,62 +359,74 @@ class AccessApiServerActive(ActiveHunter):
     def delete_item(self, path):
         headers = {}
         if self.event.auth_token:
-            headers['Authorization'] = 'Bearer {token}'.format(token=self.event.auth_token)
+            headers["Authorization"] = f"Bearer {self.event.auth_token}"
         try:
-            res = requests.delete(path, headers=headers, verify=False)
+            res = requests.delete(path, headers=headers, verify=False, timeout=config.network_timeout)
             if res.status_code in [200, 201, 202]:
                 parsed_content = json.loads(res.content)
-                return parsed_content['metadata']['deletionTimestamp']
+                return parsed_content["metadata"]["deletionTimestamp"]
         except (requests.exceptions.ConnectionError, KeyError):
             pass
         return None
 
     def create_a_pod(self, namespace, is_privileged):
-        privileged_value = ',"securityContext":{"privileged":true}' if is_privileged else ''
-        random_name = (str(uuid.uuid4()))[0:5]
-        json_pod = \
-            """
-                {{"apiVersion": "v1",
-                "kind": "Pod",
-                "metadata": {{
-                    "name": "{random_name}"
-                }},
-                "spec": {{
-                    "containers": [
-                        {{
-                            "name": "{random_name}",
-                            "image": "nginx:1.7.9",
-                            "ports": [
-                                {{
-                                    "containerPort": 80
-                                }}
-                            ]
-                            {is_privileged_flag}
-                        }}
-                    ]
-                }}
-            }}
-            """.format(random_name=random_name, is_privileged_flag=privileged_value)
-        return self.create_item(path="{path}/api/v1/namespaces/{namespace}/pods".format(
-                                path=self.path, namespace=namespace), name=random_name, data=json_pod)
+        privileged_value = {"securityContext": {"privileged": True}} if is_privileged else {}
+        random_name = str(uuid.uuid4())[0:5]
+        pod = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": random_name
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": random_name,
+                        "image": "nginx:1.7.9",
+                        "ports": [
+                            {
+                                "containerPort": 80
+                            }
+                        ],
+                        **privileged_value
+                    }
+                ]
+            }
+        }
+        return self.create_item(path=f"{self.path}/api/v1/namespaces/{namespace}/pods", data=json.dumps(pod))
 
     def delete_a_pod(self, namespace, pod_name):
         delete_timestamp = self.delete_item("{path}/api/v1/namespaces/{namespace}/pods/{name}".format(
                                           path=self.path, name=pod_name, namespace=namespace))
         if delete_timestamp is None:
-            logging.error("Created pod {name} in namespace {namespace} but unable to delete it".format(name=pod_name, namespace=namespace))
+            logging.error(f"Created pod {pod_name} in namespace {namespace} but unable to delete it")
         return delete_timestamp
 
     def patch_a_pod(self, namespace, pod_name):
-        data = '[{ "op": "add", "path": "/hello", "value": ["world"] }]'
-        return self.patch_item(path="{path}/api/v1/namespaces/{namespace}/pods/{name}".format(
-                                 path=self.path, namespace=namespace, name=pod_name),
-                                 data=data)
+        data = [
+            {
+                "op": "add",
+                "path": "/hello",
+                "value": ["world"]
+            }
+        ]
+        return self.patch_item(
+            path=f"{self.path}/api/v1/namespaces/{namespace}/pods/{pod_name}",
+            data=json.dumps(data))
 
     def create_namespace(self):
         random_name = (str(uuid.uuid4()))[0:5]
-        json = '{{"kind":"Namespace","apiVersion":"v1","metadata":{{"name":"{random_str}","labels":{{"name":"{random_str}"}}}}}}'.format(random_str=random_name)
-        return self.create_item(path="{path}/api/v1/namespaces".format(path=self.path), name=random_name, data=json)
+        data = {
+            "kind": "Namespace",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": random_name,
+                "labels": {
+                    "name": random_name
+                }
+            }
+        }
+        return self.create_item(path=f"{self.path}/api/v1/namespaces", data=json.dumps(data))
 
     def delete_namespace(self, namespace):
         delete_timestamp = self.delete_item("{path}/api/v1/namespaces/{name}".format(path=self.path, name=namespace))
@@ -405,108 +435,105 @@ class AccessApiServerActive(ActiveHunter):
         return delete_timestamp
 
     def create_a_role(self, namespace):
-        name = (str(uuid.uuid4()))[0:5]
-        role = """{{
-                          "kind": "Role",
-                          "apiVersion": "rbac.authorization.k8s.io/v1",
-                          "metadata": {{
-                            "namespace": "{namespace}",
-                            "name": "{random_str}"
-                          }},
-                          "rules": [
-                            {{
-                              "apiGroups": [
-                                ""
-                              ],
-                              "resources": [
-                                "pods"
-                              ],
-                              "verbs": [
-                                "get",
-                                "watch",
-                                "list"
-                              ]
-                            }}
-                          ]
-                        }}""".format(random_str=name, namespace=namespace)
-        return self.create_item(path="{path}/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles".format(
-                                path=self.path, namespace=namespace), name=name, data=role)
+        name = str(uuid.uuid4())[0:5]
+        role = {
+            "kind": "Role",
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "metadata": {
+                "namespace": namespace,
+                "name": name
+            },
+            "rules": [
+                {
+                    "apiGroups": [""],
+                    "resources": ["pods"],
+                    "verbs": ["get", "watch", "list"]
+                }
+            ]
+        }
+        return self.create_item(
+            path=f"{self.path}/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles",
+            data=json.dumps(role))
 
     def create_a_cluster_role(self):
-        name = (str(uuid.uuid4()))[0:5]
-        cluster_role = """{{
-                      "kind": "ClusterRole",
-                      "apiVersion": "rbac.authorization.k8s.io/v1",
-                      "metadata": {{
-                        "name": "{random_str}"
-                      }},
-                      "rules": [
-                        {{
-                          "apiGroups": [
-                            ""
-                          ],
-                          "resources": [
-                            "pods"
-                          ],
-                          "verbs": [
-                            "get",
-                            "watch",
-                            "list"
-                          ]
-                        }}
-                      ]
-                    }}""".format(random_str=name)
-        return self.create_item(path="{path}/apis/rbac.authorization.k8s.io/v1/clusterroles".format(
-                               path=self.path), name=name, data=cluster_role)
+        name = str(uuid.uuid4())[0:5]
+        cluster_role = {
+            "kind": "ClusterRole",
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "metadata": {
+               "name": name
+            },
+            "rules": [
+                {
+                    "apiGroups": [""],
+                    "resources": ["pods"],
+                    "verbs": ["get", "watch", "list"]
+                }
+            ]
+        }
+        return self.create_item(
+            path=f"{self.path}/apis/rbac.authorization.k8s.io/v1/clusterroles",
+            data=json.dumps(cluster_role))
 
     def delete_a_role(self, namespace, name):
-        delete_timestamp = self.delete_item("{path}/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{role}".format(
-            path=self.path, name=namespace, role=name))
+        delete_timestamp = self.delete_item(
+            f"{self.path}/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}")
         if delete_timestamp is None:
-            logging.error("Created role {name} in namespace {namespace} but unable to delete it".format(name=name, namespace=namespace))
+            logging.error(f"Created role {name} in namespace {namespace} but unable to delete it")
         return delete_timestamp
 
     def delete_a_cluster_role(self, name):
-        delete_timestamp = self.delete_item("{path}/apis/rbac.authorization.k8s.io/v1/clusterroles/{role}".format(
-            path=self.path, role=name))
+        delete_timestamp = self.delete_item(f"{self.path}/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}")
         if delete_timestamp is None:
-            logging.error("Created cluster role {name} but unable to delete it".format(name=name))
+            logging.error(f"Created cluster role {name} but unable to delete it")
         return delete_timestamp
 
     def patch_a_role(self, namespace, role):
-        data = '[{ "op": "add", "path": "/hello", "value": ["world"] }]'
-        return self.patch_item(path="{path}/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}".format(
-                                path=self.path, name=role, namespace=namespace),
-                                data=data)
+        data = [
+            {
+                "op": "add",
+                "path": "/hello",
+                "value": ["world"]
+            }
+        ]
+        return self.patch_item(
+            path=f"{self.path}/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{role}",
+            data=json.dumps(data))
 
     def patch_a_cluster_role(self, cluster_role):
-        data = '[{ "op": "add", "path": "/hello", "value": ["world"] }]'
-        return self.patch_item(path="{path}/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}".format(
-                                path=self.path, name=cluster_role),
-                                data=data)
+        data = [
+            {
+                "op": "add",
+                "path": "/hello",
+                "value": ["world"]
+            }
+        ]
+        return self.patch_item(
+            path=f"{self.path}/apis/rbac.authorization.k8s.io/v1/clusterroles/{cluster_role}",
+            data=json.dumps(data))
 
     def execute(self):
         # Try creating cluster-wide objects
         namespace = self.create_namespace()
         if namespace:
-            self.publish_event(CreateANamespace('new namespace name: {name}'.format(name=namespace)))
+            self.publish_event(CreateANamespace(f"new namespace name: {namespace}"))
             delete_timestamp = self.delete_namespace(namespace)
             if delete_timestamp:
                 self.publish_event(DeleteANamespace(delete_timestamp))
 
         cluster_role = self.create_a_cluster_role()
         if cluster_role:
-            self.publish_event(CreateAClusterRole('Cluster role name:  {name}'.format(name=cluster_role)))
+            self.publish_event(CreateAClusterRole(f"Cluster role name: {cluster_role}"))
 
             patch_evidence = self.patch_a_cluster_role(cluster_role)
             if patch_evidence:
-                self.publish_event(PatchAClusterRole('Patched Cluster Role Name: {name}  Patch evidence: {patch_evidence}'.format(
-                    name=cluster_role, patch_evidence=patch_evidence)))
+                self.publish_event(PatchAClusterRole(
+                    f"Patched Cluster Role Name: {cluster_role}  Patch evidence: {patch_evidence}"))
 
             delete_timestamp = self.delete_a_cluster_role(cluster_role)
             if delete_timestamp:
-                self.publish_event(DeleteAClusterRole('Cluster role {name} deletion time {delete_timestamp}'.format(
-                                                        name=cluster_role, delete_timestamp=delete_timestamp)))
+                self.publish_event(DeleteAClusterRole(
+                    f"Cluster role {cluster_role} deletion time {delete_timestamp}"))
 
         #  Try attacking all the namespaces we know about
         if self.event.namespaces:
@@ -514,47 +541,46 @@ class AccessApiServerActive(ActiveHunter):
                 # Try creating and deleting a privileged pod
                 pod_name = self.create_a_pod(namespace, True)
                 if pod_name:
-                    self.publish_event(CreateAPrivilegedPod('Pod Name: {pod_name}  Namespace: {namespace}'.format(
-                                                    pod_name=pod_name, namespace=namespace)))
+                    self.publish_event(CreateAPrivilegedPod(
+                        f"Pod Name: {pod_name}  Namespace: {namespace}"))
                     delete_time = self.delete_a_pod(namespace, pod_name)
                     if delete_time:
-                        self.publish_event(DeleteAPod('Pod Name: {pod_name}  deletion time: {delete_time}'.format(
-                                                    pod_name=pod_name, delete_evidence=delete_time)))
+                        self.publish_event(DeleteAPod(
+                            f"Pod Name: {pod_name}  deletion time: {delete_time}"))
 
                 # Try creating, patching and deleting an unprivileged pod
                 pod_name = self.create_a_pod(namespace, False)
                 if pod_name:
-                    self.publish_event(CreateAPod('Pod Name: {pod_name}  Namespace: {namespace}'.format(
-                                                    pod_name=pod_name, namespace=namespace)))
+                    self.publish_event(CreateAPod(
+                        f"Pod Name: {pod_name}  Namespace: {namespace}"))
 
                     patch_evidence = self.patch_a_pod(namespace, pod_name)
                     if patch_evidence:
-                        self.publish_event(PatchAPod('Pod Name: {pod_name}  Namespace: {namespace}  Patch evidence: {patch_evidence}'.format(
-                                                        pod_name=pod_name, namespace=namespace,
-                                                        patch_evidence=patch_evidence)))
+                        self.publish_event(PatchAPod(
+                            f"Pod Name: {pod_name}  Namespace: {namespace}  Patch evidence: {patch_evidence}"))
 
                     delete_time = self.delete_a_pod(namespace, pod_name)
                     if delete_time:
-                        self.publish_event(DeleteAPod('Pod Name: {pod_name}  Namespace: {namespace}  Delete time: {delete_time}'.format(
-                                                        pod_name=pod_name, namespace=namespace, delete_time=delete_time)))
+                        self.publish_event(DeleteAPod(
+                            f"Pod Name: {pod_name}  Namespace: {namespace}  Delete time: {delete_time}"))
 
                 role = self.create_a_role(namespace)
                 if role:
-                    self.publish_event(CreateARole('Role name:  {name}'.format(name=role)))
+                    self.publish_event(CreateARole(f"Role name: {role}"))
 
                     patch_evidence = self.patch_a_role(namespace, role)
                     if patch_evidence:
-                        self.publish_event(PatchARole('Patched Role Name: {name}  Namespace: {namespace}  Patch evidence: {patch_evidence}'.format(
-                            name=role, namespace=namespace, patch_evidence=patch_evidence)))
+                        self.publish_event(PatchARole(
+                            f"Patched Role Name: {role}  Namespace: {namespace}  Patch evidence: {patch_evidence}"))
 
                     delete_time = self.delete_a_role(namespace, role)
                     if delete_time:
-                        self.publish_event(DeleteARole('Deleted role: {name}  Namespace: {namespace}  Delete time: {delete_time}'.format(
-                                                        name=role, namespace=namespace, delete_time=delete_time)))
+                        self.publish_event(DeleteARole(
+                            f"Deleted role: {role}  Namespace: {namespace}  Delete time: {delete_time}"))
 
+            # Note: we are not binding any role or cluster role because
+            # in certain cases it might effect the running pod within the cluster (and we don't want to do that).
 
-            #  Note: we are not binding any role or cluster role because
-            # -- in certain cases it might effect the running pod within the cluster (and we don't want to do that).
 
 @handler.subscribe(ApiServer)
 class ApiVersionHunter(Hunter):
@@ -563,17 +589,18 @@ class ApiVersionHunter(Hunter):
     """
     def __init__(self, event):
         self.event = event
-        self.path = "{}://{}:{}".format(self.event.protocol, self.event.host, self.event.port)
+        self.path = f"{self.event.protocol}://{self.event.host}:{self.event.port}"
         self.session = requests.Session()
         self.session.verify = False
         if self.event.auth_token:
-            self.session.headers.update({"Authorization": "Bearer {}".format(self.event.auth_token)})
+            self.session.headers.update({"Authorization": f"Bearer {self.event.auth_token}"})
 
     def execute(self):
         if self.event.auth_token:
-            logging.debug('Passive Hunter is attempting to access the API server version end point using the pod\'s service account token on {}:{} \t'.format(self.event.host, self.event.port))
+            logging.debug("Passive Hunter is attempting to access the API server version end point using the pod's"
+                          f" service account token on {self.event.host}:{self.event.port} \t")
         else:
-            logging.debug('Passive Hunter is attempting to access the API server version end point anonymously')
-        version = json.loads(self.session.get(self.path + "/version").text)["gitVersion"]
-        logging.debug("Discovered version of api server {}".format(version))
+            logging.debug("Passive Hunter is attempting to access the API server version end point anonymously")
+        version = self.session.get(self.path + "/version", timeout=config.network_timeout).json()["gitVersion"]
+        logging.debug(f"Discovered version of api server {version}")
         self.publish_event(K8sVersionDisclosure(version=version, from_endpoint="/version"))

--- a/kube_hunter/modules/hunting/dashboard.py
+++ b/kube_hunter/modules/hunting/dashboard.py
@@ -2,6 +2,7 @@ import logging
 import json
 import requests
 
+from kube_hunter.conf import config
 from kube_hunter.core.types import Hunter, RemoteCodeExec, KubernetesCluster
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Vulnerability, Event
@@ -14,6 +15,7 @@ class DashboardExposed(Vulnerability, Event):
         Vulnerability.__init__(self, KubernetesCluster, "Dashboard Exposed", category=RemoteCodeExec, vid="KHV029")
         self.evidence = "nodes: {}".format(' '.join(nodes)) if nodes else None
 
+
 @handler.subscribe(KubeDashboardEvent)
 class KubeDashboard(Hunter):
     """Dashboard Hunting
@@ -24,7 +26,7 @@ class KubeDashboard(Hunter):
 
     def get_nodes(self):
         logging.debug("Passive hunter is attempting to get nodes types of the cluster")
-        r = requests.get("http://{}:{}/api/v1/node".format(self.event.host, self.event.port))
+        r = requests.get(f"http://{self.event.host}:{self.event.port}/api/v1/node", timeout=config.network_timwout)
         if r.status_code == 200 and "nodes" in r.text:
             return list(map(lambda node: node["objectMeta"]["name"], json.loads(r.text)["nodes"]))
 

--- a/kube_hunter/modules/hunting/dns.py
+++ b/kube_hunter/modules/hunting/dns.py
@@ -3,6 +3,7 @@ import logging
 
 from scapy.all import IP, ICMP, UDP, DNS, DNSQR, ARP, Ether, sr1, srp1, srp
 
+from kube_hunter.conf import config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, Vulnerability
 from kube_hunter.core.types import ActiveHunter, KubernetesCluster, IdentityTheft
@@ -10,7 +11,8 @@ from kube_hunter.modules.hunting.arp import PossibleArpSpoofing
 
 
 class PossibleDnsSpoofing(Vulnerability, Event):
-    """A malicious pod running on the cluster could potentially run a DNS Spoof attack and perform a MITM attack on applications running in the cluster."""
+    """A malicious pod running on the cluster could potentially run a DNS Spoof attack
+    and perform a MITM attack on applications running in the cluster."""
     def __init__(self, kubedns_pod_ip):
         Vulnerability.__init__(self, KubernetesCluster, "Possible DNS Spoof", category=IdentityTheft, vid="KHV030")
         self.kubedns_pod_ip = kubedns_pod_ip
@@ -20,17 +22,18 @@ class PossibleDnsSpoofing(Vulnerability, Event):
 @handler.subscribe(PossibleArpSpoofing)
 class DnsSpoofHunter(ActiveHunter):
     """DNS Spoof Hunter
-    Checks for the possibility for a malicious pod to compromise DNS requests of the cluster (results are based on the running node)
+    Checks for the possibility for a malicious pod to compromise DNS requests of the cluster
+    (results are based on the running node)
     """
     def __init__(self, event):
         self.event = event
 
     def get_cbr0_ip_mac(self):
-        res = srp1(Ether() / IP(dst="1.1.1.1" , ttl=1) / ICMP(), verbose=0)
+        res = srp1(Ether()/IP(dst="1.1.1.1", ttl=1)/ICMP(), verbose=0, timeout=config.network_timeout)
         return res[IP].src, res.src
 
     def extract_nameserver_ip(self):
-        with open('/etc/resolv.conf', 'r') as f:
+        with open("/etc/resolv.conf") as f:
             # finds first nameserver in /etc/resolv.conf
             match = re.search(r"nameserver (\d+.\d+.\d+.\d+)", f.read())
             if match:
@@ -40,24 +43,30 @@ class DnsSpoofHunter(ActiveHunter):
         kubedns_svc_ip = self.extract_nameserver_ip()
 
         # getting actual pod ip of kube-dns service, by comparing the src mac of a dns response and arp scanning.
-        dns_info_res = srp1(Ether() / IP(dst=kubedns_svc_ip) / UDP(dport=53) / DNS(rd=1,qd=DNSQR()), verbose=0)
+        dns_info_res = srp1(
+            Ether()/IP(dst=kubedns_svc_ip)/UDP(dport=53)/DNS(rd=1, qd=DNSQR()),
+            verbose=0,
+            timeout=config.network_timeout)
         kubedns_pod_mac = dns_info_res.src
         self_ip = dns_info_res[IP].dst
 
-        arp_responses, _ = srp(Ether(dst="ff:ff:ff:ff:ff:ff")/ARP(op=1, pdst="{}/24".format(self_ip)), timeout=3, verbose=0)
+        arp_responses, _ = srp(
+            Ether(dst="ff:ff:ff:ff:ff:ff")/ARP(op=1, pdst=f"{self_ip}/24"),
+            timeout=config.network_timeout,
+            verbose=0)
         for _, response in arp_responses:
             if response[Ether].src == kubedns_pod_mac:
                 return response[ARP].psrc, response.src
 
     def execute(self):
         logging.debug("Attempting to get kube-dns pod ip")
-        self_ip = sr1(IP(dst="1.1.1.1", ttl=1), ICMP(), verbose=0)[IP].dst
+        self_ip = sr1(IP(dst="1.1.1.1", ttl=1)/ICMP(), verbose=0, timeout=config.netork_timeout)[IP].dst
         cbr0_ip, cbr0_mac = self.get_cbr0_ip_mac()
 
         kubedns = self.get_kube_dns_ip_mac()
         if kubedns:
             kubedns_ip, kubedns_mac = kubedns
-            logging.debug("ip = {}, kubednsip = {}, cbr0ip = {}".format(self_ip, kubedns_ip, cbr0_ip))
+            logging.debug(f"ip = {self_ip}, kubednsip = {kubedns_ip}, cbr0ip = {cbr0_ip}")
             if kubedns_mac != cbr0_mac:
                 # if self pod in the same subnet as kube-dns pod
                 self.publish_event(PossibleDnsSpoofing(kubedns_pod_ip=kubedns_ip))

--- a/kube_hunter/modules/hunting/proxy.py
+++ b/kube_hunter/modules/hunting/proxy.py
@@ -1,9 +1,9 @@
 import logging
 import requests
-import json
 
 from enum import Enum
 
+from kube_hunter.conf import config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, Vulnerability, K8sVersionDisclosure
 from kube_hunter.core.types import ActiveHunter, Hunter, KubernetesCluster, InformationDisclosure
@@ -16,8 +16,10 @@ class KubeProxyExposed(Vulnerability, Event):
     def __init__(self):
         Vulnerability.__init__(self, KubernetesCluster, "Proxy Exposed", category=InformationDisclosure, vid="KHV049")
 
+
 class Service(Enum):
     DASHBOARD = "kubernetes-dashboard"
+
 
 @handler.subscribe(KubeProxyEvent)
 class KubeProxy(Hunter):
@@ -34,12 +36,13 @@ class KubeProxy(Hunter):
             for service in services:
                 if service == Service.DASHBOARD.value:
                     logging.debug(service)
-                    curr_path = "api/v1/namespaces/{ns}/services/{sv}/proxy".format(ns=namespace,sv=service) # TODO: check if /proxy is a convention on other services
+                    # TODO: check if /proxy is a convention on other services
+                    curr_path = f"api/v1/namespaces/{namespace}/services/{service}/proxy"
                     self.publish_event(KubeDashboardEvent(path=curr_path, secure=False))
 
     @property
     def namespaces(self):
-        resource_json = requests.get(self.api_url + "/namespaces").json()
+        resource_json = requests.get(self.api_url + "/namespaces", timeout=config.network_timeout).json()
         return self.extract_names(resource_json)
 
     @property
@@ -48,7 +51,7 @@ class KubeProxy(Hunter):
         services = dict()
         for namespace in self.namespaces:
             resource_path = "/namespaces/{ns}/services".format(ns=namespace)
-            resource_json = requests.get(self.api_url + resource_path).json()
+            resource_json = requests.get(self.api_url + resource_path, timeout=config.network_timeout).json()
             services[namespace] = self.extract_names(resource_json)
         logging.debug(services)
         return services
@@ -60,6 +63,7 @@ class KubeProxy(Hunter):
             names.append(item["metadata"]["name"])
         return names
 
+
 @handler.subscribe(KubeProxyExposed)
 class ProveProxyExposed(ActiveHunter):
     """Build Date Hunter
@@ -69,12 +73,13 @@ class ProveProxyExposed(ActiveHunter):
         self.event = event
 
     def execute(self):
-        version_metadata = json.loads(requests.get("http://{host}:{port}/version".format(
-            host=self.event.host,
-            port=self.event.port,
-        ), verify=False).text)
+        version_metadata = requests.get(
+            f"http://{self.event.host}:{self.event.port}/version",
+            verify=False,
+            timeout=config.network_timeout).json()
         if "buildDate" in version_metadata:
             self.event.evidence = "build date: {}".format(version_metadata["buildDate"])
+
 
 @handler.subscribe(KubeProxyExposed)
 class K8sVersionDisclosureProve(ActiveHunter):
@@ -85,9 +90,12 @@ class K8sVersionDisclosureProve(ActiveHunter):
         self.event = event
 
     def execute(self):
-        version_metadata = json.loads(requests.get("http://{host}:{port}/version".format(
-            host=self.event.host,
-            port=self.event.port,
-        ), verify=False).text)
+        version_metadata = requests.get(
+            f"http://{self.event.host}:{self.event.port}/version",
+            verify=False,
+            timeout=config.network_timeout).json()
         if "gitVersion" in version_metadata:
-            self.publish_event(K8sVersionDisclosure(version=version_metadata["gitVersion"], from_endpoint="/version", extra_info="on the kube-proxy"))
+            self.publish_event(K8sVersionDisclosure(
+                version=version_metadata["gitVersion"],
+                from_endpoint="/version",
+                extra_info="on the kube-proxy"))


### PR DESCRIPTION
## Description
When probing kube-apiserver or any other network service, timeout after given amount of seconds.

This prevents kube-hunter from running for long time, when you hit
slowly responding server during the discovery/network is blocked by firewall.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues
Fixes #35 

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Originally written by @invidian
