### PR TITLE
Optimize Cloud Discovery

### DIFF
--- a/kube_hunter/core/events/types/common.py
+++ b/kube_hunter/core/events/types/common.py
@@ -4,6 +4,7 @@ import requests
 import logging
 
 from kube_hunter.core.types import InformationDisclosure, DenialOfService, RemoteCodeExec, IdentityTheft, PrivilegeEscalation, AccessRisk, UnauthenticatedAccess, KubernetesCluster
+from kube_hunter.conf import config
 
 logger = logging.getLogger(__name__)
 
@@ -135,16 +136,11 @@ class NewHostEvent(Event):
         try:
             logger.debug("Checking whether the cluster is deployed on azure's cloud")
             # Leverage 3rd tool https://github.com/blrchen/AzureSpeed for Azure cloud ip detection
-            metadata = requests.get(f"https://api.azurespeed.com/api/region?ipOrUrl={self.host}").text
+            return requests.get(f"https://api.azurespeed.com/api/region?ipOrUrl={self.host}", timeout=config.network_timeout).json()["cloud"]
         except requests.ConnectionError:
             logger.info(f"Failed to connect cloud type service", exc_info=True)
-            return
         except Exception:
             logger.warning(f"Unable to check cloud of {self.host}", exc_info=True)
-        if "cloud" in metadata:
-            return json.loads(metadata)["cloud"]
-        else:
-            return "NoCloud"
         
     def __str__(self):
         return str(self.host)

--- a/kube_hunter/core/events/types/common.py
+++ b/kube_hunter/core/events/types/common.py
@@ -2,7 +2,6 @@ import threading
 import json
 import requests
 import logging
-from cached_property import cached_property
 
 from kube_hunter.core.types import InformationDisclosure, DenialOfService, RemoteCodeExec, IdentityTheft, PrivilegeEscalation, AccessRisk, UnauthenticatedAccess, KubernetesCluster
 
@@ -126,7 +125,7 @@ class NewHostEvent(Event):
             self.event_id = event_id_count
             event_id_count += 1
 
-    @cached_property
+    @property
     def cloud(self):
         if not self.cloud_type:
             self.cloud_type = self.get_cloud()
@@ -144,6 +143,8 @@ class NewHostEvent(Event):
             logger.warning(f"Unable to check cloud of {self.host}", exc_info=True)
         if "cloud" in metadata:
             return json.loads(metadata)["cloud"]
+        else:
+            return "NoCloud"
         
     def __str__(self):
         return str(self.host)

--- a/kube_hunter/core/events/types/common.py
+++ b/kube_hunter/core/events/types/common.py
@@ -142,6 +142,7 @@ class NewHostEvent(Event):
             logger.info(f"Failed to connect cloud type service", exc_info=True)
         except Exception:
             logger.warning(f"Unable to check cloud of {self.host}", exc_info=True)
+        return "NoCloud"
         
     def __str__(self):
         return str(self.host)

--- a/kube_hunter/core/events/types/common.py
+++ b/kube_hunter/core/events/types/common.py
@@ -1,12 +1,13 @@
 import threading
-import json
 import requests
 import logging
 
-from kube_hunter.core.types import InformationDisclosure, DenialOfService, RemoteCodeExec, IdentityTheft, PrivilegeEscalation, AccessRisk, UnauthenticatedAccess, KubernetesCluster
+from kube_hunter.core.types import InformationDisclosure, DenialOfService, RemoteCodeExec, IdentityTheft, \
+    PrivilegeEscalation, AccessRisk, UnauthenticatedAccess, KubernetesCluster
 from kube_hunter.conf import config
 
 logger = logging.getLogger(__name__)
+
 
 class EventFilterBase(object):
     def __init__(self, event):
@@ -17,6 +18,7 @@ class EventFilterBase(object):
     # Return None to indicate the event should be discarded
     def execute(self):
         return self.event
+
 
 class Event(object):
     def __init__(self):
@@ -109,6 +111,7 @@ class Vulnerability(object):
     def get_severity(self):
         return self.severity.get(self.category, "low")
 
+
 global event_id_count_lock
 event_id_count_lock = threading.Lock()
 event_id_count = 0
@@ -136,14 +139,16 @@ class NewHostEvent(Event):
         try:
             logger.debug("Checking whether the cluster is deployed on azure's cloud")
             # Leverage 3rd tool https://github.com/blrchen/AzureSpeed for Azure cloud ip detection
-            result = requests.get(f"https://api.azurespeed.com/api/region?ipOrUrl={self.host}", timeout=config.network_timeout).json()
+            result = \
+                requests.get(f"https://api.azurespeed.com/api/region?ipOrUrl={self.host}",
+                             timeout=config.network_timeout).json()
             return result["cloud"] or "NoCloud"
         except requests.ConnectionError:
             logger.info(f"Failed to connect cloud type service", exc_info=True)
         except Exception:
             logger.warning(f"Unable to check cloud of {self.host}", exc_info=True)
         return "NoCloud"
-        
+     
     def __str__(self):
         return str(self.host)
     
@@ -151,13 +156,14 @@ class NewHostEvent(Event):
     def location(self):
         return str(self.host)
 
+
 class OpenPortEvent(Event):
     def __init__(self, port):
         self.port = port
-    
+        
     def __str__(self):
         return str(self.port)
-    
+       
     # Event's logical location to be used mainly for reports.
     def location(self):
         if self.host:

--- a/kube_hunter/core/events/types/common.py
+++ b/kube_hunter/core/events/types/common.py
@@ -136,7 +136,8 @@ class NewHostEvent(Event):
         try:
             logger.debug("Checking whether the cluster is deployed on azure's cloud")
             # Leverage 3rd tool https://github.com/blrchen/AzureSpeed for Azure cloud ip detection
-            return requests.get(f"https://api.azurespeed.com/api/region?ipOrUrl={self.host}", timeout=config.network_timeout).json()["cloud"]
+            result = requests.get(f"https://api.azurespeed.com/api/region?ipOrUrl={self.host}", timeout=config.network_timeout).json()
+            return result["cloud"] or "NoCloud"
         except requests.ConnectionError:
             logger.info(f"Failed to connect cloud type service", exc_info=True)
         except Exception:

--- a/kube_hunter/modules/discovery/hosts.py
+++ b/kube_hunter/modules/discovery/hosts.py
@@ -55,20 +55,6 @@ class HostScanEvent(Event):
 
 
 class HostDiscoveryHelpers:
-    @staticmethod
-    def get_cloud(host):
-        try:
-            logger.debug("Checking whether the cluster is deployed on azure's cloud")
-            # Leverage 3rd tool https://github.com/blrchen/AzureSpeed for Azure cloud ip detection
-            metadata = requests.get(f"https://api.azurespeed.com/api/region?ipOrUrl={host}").text
-        except requests.ConnectionError as e:
-            logger.info(f"Failed to connect cloud type service", exc_info=True)
-            return
-        except Exception:
-            logger.warning(f"Unable to check cloud of {host}", exc_info=True)
-        if "cloud" in metadata:
-            return json.loads(metadata)["cloud"]
-
     # generator, generating a subnet by given a cidr
     @staticmethod
     def generate_subnet(ip, sn="24"):
@@ -168,14 +154,13 @@ class HostDiscovery(Discovery):
             except ValueError as e:
                 logger.exception(f"Unable to parse CIDR \"{config.cidr}\"")
                 return
-            cloud = HostDiscoveryHelpers.get_cloud(ip)
             for ip in HostDiscoveryHelpers.generate_subnet(ip, sn=sn):
-                self.publish_event(NewHostEvent(host=ip, cloud=cloud))
+                self.publish_event(NewHostEvent(host=ip))
         elif config.interface:
             self.scan_interfaces()
         elif len(config.remote) > 0:
             for host in config.remote:
-                self.publish_event(NewHostEvent(host=host, cloud=HostDiscoveryHelpers.get_cloud(host)))
+                self.publish_event(NewHostEvent(host=host))
 
     # for normal scanning
     def scan_interfaces(self):
@@ -186,9 +171,8 @@ class HostDiscovery(Discovery):
         except requests.ConnectionError as e:
             logger.warning(f"Unable to determine external IP address, using 127.0.0.1", exc_info=True)
             external_ip = "127.0.0.1"
-        cloud = HostDiscoveryHelpers.get_cloud(external_ip)
         for ip in self.generate_interfaces_subnet():
-            handler.publish_event(NewHostEvent(host=ip, cloud=cloud))
+            handler.publish_event(NewHostEvent(host=ip))
 
     # generate all subnets from all internal network interfaces
     def generate_interfaces_subnet(self, sn='24'):

--- a/kube_hunter/modules/discovery/hosts.py
+++ b/kube_hunter/modules/discovery/hosts.py
@@ -1,5 +1,4 @@
 import os
-import json
 import logging
 import requests
 
@@ -152,7 +151,7 @@ class HostDiscovery(Discovery):
         if config.cidr:
             try:
                 ip, sn = config.cidr.split('/')
-            except ValueError as e:
+            except ValueError:
                 logger.exception(f"Unable to parse CIDR \"{config.cidr}\"")
                 return
             for ip in HostDiscoveryHelpers.generate_subnet(ip, sn=sn):
@@ -169,7 +168,7 @@ class HostDiscovery(Discovery):
             logger.debug("HostDiscovery hunter attempting to get external IP address")
             # getting external ip, to determine if cloud cluster
             external_ip = requests.get("https://canhazip.com", timeout=config.network_timeout).text
-        except requests.ConnectionError as e:
+        except requests.ConnectionError:
             logger.warning(f"Unable to determine external IP address, using 127.0.0.1", exc_info=True)
             external_ip = "127.0.0.1"
         for ip in self.generate_interfaces_subnet():

--- a/kube_hunter/modules/discovery/hosts.py
+++ b/kube_hunter/modules/discovery/hosts.py
@@ -80,9 +80,9 @@ class FromPodHostDiscovery(Discovery):
         else:
             # Discover cluster subnets, we'll scan all these hosts
             if self.is_azure_pod():
-                subnets, cloud = self.azure_metadata_discovery()
+                subnets = self.azure_metadata_discovery()
             else:
-                subnets, cloud = self.traceroute_discovery()
+                subnets, ext_ip = self.traceroute_discovery()
 
             should_scan_apiserver = False
             if self.event.kubeservicehost:
@@ -92,9 +92,9 @@ class FromPodHostDiscovery(Discovery):
                     should_scan_apiserver = False
                 logger.debug(f"From pod scanning subnet {subnet[0]}/{subnet[1]}")
                 for ip in HostDiscoveryHelpers.generate_subnet(ip=subnet[0], sn=subnet[1]):
-                    self.publish_event(NewHostEvent(host=ip, cloud=cloud))
+                    self.publish_event(NewHostEvent(host=ip))
             if should_scan_apiserver:
-                self.publish_event(NewHostEvent(host=IPAddress(self.event.kubeservicehost), cloud=cloud))
+                self.publish_event(NewHostEvent(host=IPAddress(self.event.kubeservicehost)))
 
     def is_azure_pod(self):
         try:
@@ -136,7 +136,7 @@ class FromPodHostDiscovery(Discovery):
 
             self.publish_event(AzureMetadataApi(cidr=f"{address}/{subnet}"))
 
-        return subnets, "Azure"
+        return subnets
 
 
 @handler.subscribe(HostScanEvent)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     PrettyTable
     urllib3>=1.24.3
     ruamel.yaml
+    cached-property
     future
     packaging
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     PrettyTable
     urllib3>=1.24.3
     ruamel.yaml
-    cached-property
     future
     packaging
 setup_requires =

--- a/tests/core/test_cloud.py
+++ b/tests/core/test_cloud.py
@@ -12,6 +12,14 @@ def test_presetcloud():
     assert expcted == hostEvent.cloud
 
 
+# Test if we can dynamic assign a cloud, without calling get_cloud
+def test_dynamiccloud():
+    expected = "Google Cloud"
+    hostEvent = NewHostEvent(host="1.2.3.4")
+    hostEvent.cloud = expected
+    assert hostEvent.cloud == expected
+
+
 def test_getcloud():
     fake_host = "1.2.3.4"
     expected_cloud = "Azure"

--- a/tests/core/test_cloud.py
+++ b/tests/core/test_cloud.py
@@ -1,3 +1,6 @@
+import requests_mock
+import json
+
 from kube_hunter.core.events.types.common import NewHostEvent
 
 
@@ -10,9 +13,19 @@ def test_presetcloud():
 
 
 def test_getcloud():
-    AZURE_SERVER = "52.224.188.147" # this is portal.azure.com DNS record
-    expected = "Azure"
-    hostEvent = NewHostEvent(host=AZURE_SERVER)
+    fake_host = "1.2.3.4"
+    expected_cloud = "Azure"
+    result = {
+        "cloud": expected_cloud,
+        "regionId": "europenorth",
+        "region":"North Europe",
+        "location":"Ireland",
+        "ipAddress": fake_host
+    }
     
-    assert hostEvent.cloud == expected
+    with requests_mock.mock() as m:
+        m.get(f'https://api.azurespeed.com/api/region?ipOrUrl={fake_host}',
+              text=json.dumps(result))
+        hostEvent = NewHostEvent(host=fake_host)
+        assert hostEvent.cloud == expected_cloud
     

--- a/tests/core/test_cloud.py
+++ b/tests/core/test_cloud.py
@@ -16,11 +16,7 @@ def test_getcloud():
     fake_host = "1.2.3.4"
     expected_cloud = "Azure"
     result = {
-        "cloud": expected_cloud,
-        "regionId": "europenorth",
-        "region":"North Europe",
-        "location":"Ireland",
-        "ipAddress": fake_host
+        "cloud": expected_cloud
     }
     
     with requests_mock.mock() as m:

--- a/tests/core/test_cloud.py
+++ b/tests/core/test_cloud.py
@@ -1,0 +1,18 @@
+from kube_hunter.core.events.types.common import NewHostEvent
+
+
+# Testing if it doesn't try to run get_cloud if the cloud type is already set.
+# get_cloud(1.2.3.4) will result with an error
+def test_presetcloud():
+    expcted = "AWS"
+    hostEvent = NewHostEvent(host="1.2.3.4", cloud=expcted)
+    assert expcted == hostEvent.cloud
+
+
+def test_getcloud():
+    AZURE_SERVER = "52.224.188.147" # this is portal.azure.com DNS record
+    expected = "Azure"
+    hostEvent = NewHostEvent(host=AZURE_SERVER)
+    
+    assert hostEvent.cloud == expected
+    

--- a/tests/core/test_cloud.py
+++ b/tests/core/test_cloud.py
@@ -12,14 +12,6 @@ def test_presetcloud():
     assert expcted == hostEvent.cloud
 
 
-# Test if we can dynamic assign a cloud, without calling get_cloud
-def test_dynamiccloud():
-    expected = "Google Cloud"
-    hostEvent = NewHostEvent(host="1.2.3.4")
-    hostEvent.cloud = expected
-    assert hostEvent.cloud == expected
-
-
 def test_getcloud():
     fake_host = "1.2.3.4"
     expected_cloud = "Azure"


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Switched get_cloud() to a lazy load, using cached_property.
Now only when you access event.cloud it will load what cloud it is.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues
Resolves #324 

## "BEFORE" and "AFTER" output
Output shouldnt be different

## Contribution checklist
 - [X] I have read the Contributing Guidelines.
 - [X] The commits refer to an active issue in the repository.
 - [X] I have added automated testing to cover this case.
