### PR TITLE
Dashboard hunter not working

### DIFF
--- a/kube_hunter/modules/hunting/dashboard.py
+++ b/kube_hunter/modules/hunting/dashboard.py
@@ -32,7 +32,7 @@ class KubeDashboard(Hunter):
 
     def get_nodes(self):
         logger.debug("Passive hunter is attempting to get nodes types of the cluster")
-        r = requests.get(f"http://{self.event.host}:{self.event.port}/api/v1/node", timeout=config.network_timwout)
+        r = requests.get(f"http://{self.event.host}:{self.event.port}/api/v1/node", timeout=config.network_timeout)
         if r.status_code == 200 and "nodes" in r.text:
             return [node["objectMeta"]["name"] for node in json.loads(r.text)["nodes"]]
 

--- a/tests/hunting/test_dashboard.py
+++ b/tests/hunting/test_dashboard.py
@@ -1,0 +1,37 @@
+import json
+
+from types import SimpleNamespace
+from requests_mock import Mocker
+from kube_hunter.modules.hunting.dashboard import KubeDashboard
+
+
+class TestKubeDashboard:
+    @staticmethod
+    def get_nodes_mock(result: dict, **kwargs):
+        with Mocker() as m:
+            m.get("http://mockdashboard:8000/api/v1/node", text=json.dumps(result), **kwargs)
+            hunter = KubeDashboard(SimpleNamespace(host="mockdashboard", port=8000))
+            return hunter.get_nodes()
+
+    @staticmethod
+    def test_get_nodes_with_result():
+        nodes = {"nodes": [{"objectMeta": {"name": "node1"}}]}
+        expected = ["node1"]
+        actual = TestKubeDashboard.get_nodes_mock(nodes)
+
+        assert expected == actual
+
+    @staticmethod
+    def test_get_nodes_without_result():
+        nodes = {"nodes": []}
+        expected = []
+        actual = TestKubeDashboard.get_nodes_mock(nodes)
+
+        assert expected == actual
+
+    @staticmethod
+    def test_get_nodes_invalid_result():
+        expected = None
+        actual = TestKubeDashboard.get_nodes_mock(dict(), status_code=404)
+
+        assert expected == actual


### PR DESCRIPTION
solves #336, just a typo.

<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
There was a typo in dashboard.py calling network_timwout instead of network_timeout

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues

Fixes #336 

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

### BEFORE
Dashboard hunter not-working

### AFTER
Dashboard hunter working

## Contribution checklist
 - [X] I have read the Contributing Guidelines.
 - [X] The commits refer to an active issue in the repository.
 - [X] I have added automated testing to cover this case.
 
## Notes

