### PR TITLE
Removed unused imports

### DIFF
--- a/kube_hunter/README.md
+++ b/kube_hunter/README.md
@@ -75,10 +75,10 @@ in order to prevent circular dependency bug.
 
 Following the above example, let's figure out the imports:  
 ```python  
-from ...core.types import Hunter  
-from ...core.events import handler  
+from kube_hunter.core.types import Hunter  
+from kube_hunter.core.events import handler  
   
-from ...core.events.types import OpenPortEvent  
+from kube_hunter.core.events.types import OpenPortEvent  
   
 @handler.subscribe(OpenPortEvent, predicate=lambda event: event.port == 30000)  
 class KubeDashboardDiscovery(Hunter):  
@@ -90,13 +90,13 @@ class KubeDashboardDiscovery(Hunter):
 As you can see, all of the types here come from the `core` module. 
   
 ### Core Imports  
-relative import: `...core.events`  
+Absolute import: `kube_hunter.core.events`  
 
 |Name|Description|
 |---|---|
 |handler|Core object for using events, every module should import this object|
 
-relative import `...core.events.types`  
+Absolute import `kube_hunter.core.events.types`  
 
 |Name|Description|
 |---|---|
@@ -104,7 +104,7 @@ relative import `...core.events.types`
 |Vulnerability|Base class for defining a new vulnerability|
 |OpenPortEvent|Published when a new port is discovered. open port is assigned to the `port ` attribute|
   
-relative import: `...core.types`  
+Absolute import: `kube_hunter.core.types`  
 
 |Type|Description|
 |---|---|

--- a/kube_hunter/__init__.py
+++ b/kube_hunter/__init__.py
@@ -1,4 +1,0 @@
-from . import core
-from . import modules
-
-__all__ = [core, modules]

--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -13,8 +13,6 @@ config.reporter = get_reporter(config.report)
 config.dispatcher = get_dispatcher(config.dispatch)
 logger = logging.getLogger(__name__)
 
-import kube_hunter  # noqa
-
 
 def interactive_set_config():
     """Sets config manually, returns True for success"""

--- a/tests/core/test_handler.py
+++ b/tests/core/test_handler.py
@@ -1,3 +1,9 @@
+# flake8: noqa: E402
+
+from kube_hunter.conf import config
+
+config.active = True
+
 from kube_hunter.core.events.handler import handler
 from kube_hunter.modules.discovery.apiserver import ApiServiceDiscovery
 from kube_hunter.modules.discovery.dashboard import KubeDashboard as KubeDashboardDiscovery
@@ -90,23 +96,20 @@ def test_passive_hunters_registered():
     assert expected_odd == actual_odd, "Unexpected passive hunters are registered"
 
 
-# TODO (#334): Active hunters registration cannot be tested since it requires `config.active` to be set
-# def test_active_hunters_registered():
-#     expected_missing = set()
-#     expected_odd = set()
-#
-#     registered_active = remove_test_hunters(handler.active_hunters.keys())
-#     actual_missing = ACTIVE_HUNTERS - registered_active
-#     actual_odd = registered_active - ACTIVE_HUNTERS
-#
-#     assert expected_missing == actual_missing, "Active hunters are missing"
-#     assert expected_odd == actual_odd, "Unexpected active hunters are registered"
+def test_active_hunters_registered():
+    expected_missing = set()
+    expected_odd = set()
+
+    registered_active = remove_test_hunters(handler.active_hunters.keys())
+    actual_missing = ACTIVE_HUNTERS - registered_active
+    actual_odd = registered_active - ACTIVE_HUNTERS
+
+    assert expected_missing == actual_missing, "Active hunters are missing"
+    assert expected_odd == actual_odd, "Unexpected active hunters are registered"
 
 
 def test_all_hunters_registered():
-    # TODO: Enable active hunting mode in testing
-    # expected = PASSIVE_HUNTERS | ACTIVE_HUNTERS
-    expected = PASSIVE_HUNTERS
+    expected = PASSIVE_HUNTERS | ACTIVE_HUNTERS
     actual = remove_test_hunters(handler.all_hunters.keys())
 
     assert expected == actual


### PR DESCRIPTION
## Description
Previously, kube_hunter imported it's all code base in it's `__init__.py` file.
It caused hunter registration to happen before being able to set config (impacts on testing).

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues
Resolves #334 

## Contribution checklist
 - [X] I have read the Contributing Guidelines.
 - [X] The commits refer to an active issue in the repository.
 - [X] I have added automated testing to cover this case.
 
## Notes
