### PR TITLE
Decouple config and argument parsing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
-ignore = E203, E266, E501, W503, B903
+ignore = E203, E266, E501, W503, B903, T499
 max-line-length = 120
 max-complexity = 18
-select = B,C,E,F,W,B9
+select = B,C,E,F,W,B9,T4
+mypy_config=mypy.ini

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ var/
 .DS_Store
 thumbs.db
 __pycache__
+.mypy_cache

--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,5 @@ publish:
 
 .PHONY: clean
 clean:
-	rm -rf build/ dist/ *.egg-info/ .eggs/ .pytest_cache/ .coverage *.spec
+	rm -rf build/ dist/ *.egg-info/ .eggs/ .pytest_cache/ .mypy_cache .coverage *.spec
 	find . -type d -name __pycache__ -exec rm -rf '{}' +

--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -1,59 +1,50 @@
-from dataclasses import dataclass, field
-from typing import Sequence
-from kube_hunter.conf.parser import parse_args
-from kube_hunter.conf.logging import setup_logger
+from dataclasses import dataclass
+from typing import Any, Optional
 
 
 @dataclass
 class Config:
     """ Config is a configuration container.
     It contains the following fields:
+    - active: Enable active hunters
+    - cidr: Network subnets to scan
+    - dispatcher: Dispatcher object
+    - include_patched_version: Include patches in version comparison
     - interface: Interface scanning mode
+    - list_hunters: Print a list of existing hunters
+    - log_level: Log level
+    - mapping: Report only found components
+    - network_timeout: Timeout for network operations
     - pod: From pod scanning mode
     - quick: Quick scanning mode
-    - include_patched_version: Version comparison include patches
-    - cidr: Network subnets to scan
-    - mapping: Report only found components
     - remote: Hosts to scan
-    - active: Enable active hunters
-    - log: Log level
     - report: Output format
-    - dispatch: Output target
     - statistics: Include hunters statistics
-    - network_timeout: Timeout for network operations
     """
 
+    active: bool = False
+    cidr: Optional[str] = None
+    dispatcher: Optional[Any] = None
+    include_patched_versions: bool = False
     interface: bool = False
+    mapping: bool = False
+    network_timeout: float = 5.0
     pod: bool = False
     quick: bool = False
-    include_patched_versions: bool = False
-    cidr: Sequence[str] = field(default_factory=list)
-    mapping: bool = False
-    remote: Sequence[str] = field(default_factory=list)
-    active: bool = False
-    log_level: str = "INFO"
-    report: str = "plain"
-    dispatch: str = "stdout"
+    remote: Optional[str] = None
+    reporter: Optional[Any] = None
     statistics: bool = False
-    network_timeout: float = 5.0
 
 
-_parsed = parse_args()
-config: Config = Config(
-    interface=_parsed.interface,
-    pod=_parsed.pod,
-    quick=_parsed.quick,
-    include_patched_versions=_parsed.include_patched_versions,
-    cidr=_parsed.cidr,
-    mapping=_parsed.mapping,
-    remote=_parsed.remote,
-    active=_parsed.active,
-    log_level=_parsed.log,
-    report=_parsed.report,
-    dispatch=_parsed.dispatch,
-    statistics=_parsed.statistics,
-    network_timeout=_parsed.network_timeout,
-)
-setup_logger(config.log_level)
+_config: Optional[Config] = None
 
-__all__ = [Config, parse_args, setup_logger, config]
+
+def get_config() -> Config:
+    if not _config:
+        raise ValueError("Configuration is not initialized")
+    return _config
+
+
+def set_config(new_config: Config) -> None:
+    global _config
+    _config = new_config

--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -1,8 +1,59 @@
+from dataclasses import dataclass, field
+from typing import Sequence
 from kube_hunter.conf.parser import parse_args
 from kube_hunter.conf.logging import setup_logger
 
 
-config = parse_args()
-setup_logger(config.log)
+@dataclass
+class Config:
+    """ Config is a configuration container.
+    It contains the following fields:
+    - interface: Interface scanning mode
+    - pod: From pod scanning mode
+    - quick: Quick scanning mode
+    - include_patched_version: Version comparison include patches
+    - cidr: Network subnets to scan
+    - mapping: Report only found components
+    - remote: Hosts to scan
+    - active: Enable active hunters
+    - log: Log level
+    - report: Output format
+    - dispatch: Output target
+    - statistics: Include hunters statistics
+    - network_timeout: Timeout for network operations
+    """
 
-__all__ = [config]
+    interface: bool = False
+    pod: bool = False
+    quick: bool = False
+    include_patched_versions: bool = False
+    cidr: Sequence[str] = field(default_factory=list)
+    mapping: bool = False
+    remote: Sequence[str] = field(default_factory=list)
+    active: bool = False
+    log_level: str = "INFO"
+    report: str = "plain"
+    dispatch: str = "stdout"
+    statistics: bool = False
+    network_timeout: float = 5.0
+
+
+_parsed = parse_args()
+config: Config = Config(
+    interface=_parsed.interface,
+    pod=_parsed.pod,
+    quick=_parsed.quick,
+    include_patched_versions=_parsed.include_patched_versions,
+    cidr=_parsed.cidr,
+    mapping=_parsed.mapping,
+    remote=_parsed.remote,
+    active=_parsed.active,
+    log_level=_parsed.log,
+    report=_parsed.report,
+    dispatch=_parsed.dispatch,
+    statistics=_parsed.statistics,
+    network_timeout=_parsed.network_timeout,
+)
+setup_logger(config.log_level)
+
+__all__ = [Config, parse_args, setup_logger, config]

--- a/kube_hunter/conf/logging.py
+++ b/kube_hunter/conf/logging.py
@@ -21,7 +21,7 @@ def setup_logger(level_name):
         logging.disable(logging.CRITICAL)
     else:
         log_level = getattr(logging, level_name.upper(), None)
-        log_level = log_level if type(log_level) is int else None
+        log_level = log_level if isinstance(log_level, int) else None
         logging.basicConfig(level=log_level or DEFAULT_LEVEL, format=LOG_FORMAT)
         if not log_level:
             logging.warning(f"Unknown log level '{level_name}', using {DEFAULT_LEVEL_NAME}")

--- a/kube_hunter/core/__init__.py
+++ b/kube_hunter/core/__init__.py
@@ -1,4 +1,3 @@
+# flake8: noqa: E402
 from . import types
 from . import events
-
-__all__ = [types, events]

--- a/kube_hunter/core/events/__init__.py
+++ b/kube_hunter/core/events/__init__.py
@@ -1,4 +1,3 @@
+# flake8: noqa: E402
 from .handler import EventQueue, handler
 from . import types
-
-__all__ = [EventQueue, handler, types]

--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from queue import Queue
 from threading import Thread
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.types import ActiveHunter, HunterBase
 from kube_hunter.core.events.types import Vulnerability, EventFilterBase
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 # Inherits Queue object, handles events asynchronously
-class EventQueue(Queue, object):
+class EventQueue(Queue):
     def __init__(self, num_worker=10):
         super(EventQueue, self).__init__()
         self.passive_hunters = dict()
@@ -60,6 +60,7 @@ class EventQueue(Queue, object):
 
     # getting uninstantiated event object
     def subscribe_event(self, event, hook=None, predicate=None):
+        config = get_config()
         if ActiveHunter in hook.__mro__:
             if not config.active:
                 return
@@ -98,6 +99,8 @@ class EventQueue(Queue, object):
 
     # getting instantiated event object
     def publish_event(self, event, caller=None):
+        config = get_config()
+
         # setting event chain
         if caller:
             event.previous = caller.event

--- a/kube_hunter/core/events/types.py
+++ b/kube_hunter/core/events/types.py
@@ -1,8 +1,8 @@
+import logging
 import threading
 import requests
-import logging
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.types import (
     InformationDisclosure,
     DenialOfService,
@@ -17,7 +17,7 @@ from kube_hunter.core.types import (
 logger = logging.getLogger(__name__)
 
 
-class EventFilterBase(object):
+class EventFilterBase:
     def __init__(self, event):
         self.event = event
 
@@ -28,7 +28,7 @@ class EventFilterBase(object):
         return self.event
 
 
-class Event(object):
+class Event:
     def __init__(self):
         self.previous = None
         self.hunter = None
@@ -62,7 +62,7 @@ class Event(object):
         return history
 
 
-class Service(object):
+class Service:
     def __init__(self, name, path="", secure=True):
         self.name = name
         self.secure = secure
@@ -79,7 +79,7 @@ class Service(object):
         return self.__doc__
 
 
-class Vulnerability(object):
+class Vulnerability:
     severity = dict(
         {
             InformationDisclosure: "medium",
@@ -118,7 +118,6 @@ class Vulnerability(object):
         return self.severity.get(self.category, "low")
 
 
-global event_id_count_lock
 event_id_count_lock = threading.Lock()
 event_id_count = 0
 
@@ -140,6 +139,7 @@ class NewHostEvent(Event):
         return self.cloud_type
 
     def get_cloud(self):
+        config = get_config()
         try:
             logger.debug("Checking whether the cluster is deployed on azure's cloud")
             # Leverage 3rd tool https://github.com/blrchen/AzureSpeed for Azure cloud ip detection

--- a/kube_hunter/core/types.py
+++ b/kube_hunter/core/types.py
@@ -1,4 +1,4 @@
-class HunterBase(object):
+class HunterBase:
     publishedVulnerabilities = 0
 
     @staticmethod

--- a/kube_hunter/modules/__init__.py
+++ b/kube_hunter/modules/__init__.py
@@ -1,5 +1,4 @@
+# flake8: noqa: E402
 from . import report
 from . import discovery
 from . import hunting
-
-__all__ = [report, discovery, hunting]

--- a/kube_hunter/modules/discovery/__init__.py
+++ b/kube_hunter/modules/discovery/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E402
 from . import (
     apiserver,
     dashboard,
@@ -8,14 +9,3 @@ from . import (
     ports,
     proxy,
 )
-
-__all__ = [
-    apiserver,
-    dashboard,
-    etcd,
-    hosts,
-    kubectl,
-    kubelet,
-    ports,
-    proxy,
-]

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -1,11 +1,11 @@
-import requests
 import logging
+import requests
 
 from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import OpenPortEvent, Service, Event, EventFilterBase
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 
 KNOWN_API_PORTS = [443, 6443, 8080]
 
@@ -57,6 +57,7 @@ class ApiServiceDiscovery(Discovery):
                 self.publish_event(K8sApiService(protocol))
 
     def has_api_behaviour(self, protocol):
+        config = get_config()
         try:
             r = self.session.get(f"{protocol}://{self.event.host}:{self.event.port}", timeout=config.network_timeout)
             if ("k8s" in r.text) or ('"code"' in r.text and r.status_code != 200):
@@ -93,6 +94,7 @@ class ApiServiceClassify(EventFilterBase):
 
     def classify_using_version_endpoint(self):
         """Tries to classify by accessing /version. if could not access succeded, returns"""
+        config = get_config()
         try:
             endpoint = f"{self.event.protocol}://{self.event.host}:{self.event.port}/version"
             versions = self.session.get(endpoint, timeout=config.network_timeout).json()

--- a/kube_hunter/modules/discovery/dashboard.py
+++ b/kube_hunter/modules/discovery/dashboard.py
@@ -2,7 +2,7 @@ import json
 import logging
 import requests
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, OpenPortEvent, Service
 from kube_hunter.core.types import Discovery
@@ -28,6 +28,7 @@ class KubeDashboard(Discovery):
 
     @property
     def secure(self):
+        config = get_config()
         endpoint = f"http://{self.event.host}:{self.event.port}/api/v1/service/default"
         logger.debug("Attempting to discover an Api server to access dashboard")
         try:

--- a/kube_hunter/modules/discovery/kubelet.py
+++ b/kube_hunter/modules/discovery/kubelet.py
@@ -3,7 +3,7 @@ import requests
 import urllib3
 from enum import Enum
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import OpenPortEvent, Event, Service
@@ -47,6 +47,7 @@ class KubeletDiscovery(Discovery):
         self.event = event
 
     def get_read_only_access(self):
+        config = get_config()
         endpoint = f"http://{self.event.host}:{self.event.port}/pods"
         logger.debug(f"Trying to get kubelet read access at {endpoint}")
         r = requests.get(endpoint, timeout=config.network_timeout)
@@ -64,6 +65,7 @@ class KubeletDiscovery(Discovery):
             self.publish_event(SecureKubeletEvent(secure=True, anonymous_auth=False))
 
     def ping_kubelet(self):
+        config = get_config()
         endpoint = f"https://{self.event.host}:{self.event.port}/pods"
         logger.debug("Attempting to get pods info from kubelet")
         try:

--- a/kube_hunter/modules/discovery/proxy.py
+++ b/kube_hunter/modules/discovery/proxy.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Service, Event, OpenPortEvent
@@ -29,6 +29,7 @@ class KubeProxy(Discovery):
 
     @property
     def accesible(self):
+        config = get_config()
         endpoint = f"http://{self.host}:{self.port}/api/v1"
         logger.debug("Attempting to discover a proxy service")
         try:

--- a/kube_hunter/modules/hunting/__init__.py
+++ b/kube_hunter/modules/hunting/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E402
 from . import (
     aks,
     apiserver,
@@ -13,19 +14,3 @@ from . import (
     proxy,
     secrets,
 )
-
-__all__ = [
-    aks,
-    apiserver,
-    arp,
-    capabilities,
-    certificates,
-    cves,
-    dashboard,
-    dns,
-    etcd,
-    kubelet,
-    mounts,
-    proxy,
-    secrets,
-]

--- a/kube_hunter/modules/hunting/aks.py
+++ b/kube_hunter/modules/hunting/aks.py
@@ -2,7 +2,7 @@ import json
 import logging
 import requests
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.modules.hunting.kubelet import ExposedRunHandler
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, Vulnerability
@@ -33,6 +33,7 @@ class AzureSpnHunter(Hunter):
 
     # getting a container that has access to the azure.json file
     def get_key_container(self):
+        config = get_config()
         endpoint = f"{self.base_url}/pods"
         logger.debug("Trying to find container with access to azure.json file")
         try:
@@ -69,6 +70,7 @@ class ProveAzureSpnExposure(ActiveHunter):
         self.base_url = f"https://{self.event.host}:{self.event.port}"
 
     def run(self, command, container):
+        config = get_config()
         run_url = "/".join(self.base_url, "run", container["namespace"], container["pod"], container["name"])
         return requests.post(run_url, verify=False, params={"cmd": command}, timeout=config.network_timeout)
 

--- a/kube_hunter/modules/hunting/apiserver.py
+++ b/kube_hunter/modules/hunting/apiserver.py
@@ -1,9 +1,9 @@
 import logging
 import json
-import requests
 import uuid
+import requests
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.modules.discovery.apiserver import ApiServer
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Vulnerability, Event, K8sVersionDisclosure
@@ -236,6 +236,7 @@ class AccessApiServer(Hunter):
         self.with_token = False
 
     def access_api_server(self):
+        config = get_config()
         logger.debug(f"Passive Hunter is attempting to access the API at {self.path}")
         try:
             r = requests.get(f"{self.path}/api", headers=self.headers, verify=False, timeout=config.network_timeout)
@@ -246,6 +247,7 @@ class AccessApiServer(Hunter):
         return False
 
     def get_items(self, path):
+        config = get_config()
         try:
             items = []
             r = requests.get(path, headers=self.headers, verify=False, timeout=config.network_timeout)
@@ -261,6 +263,7 @@ class AccessApiServer(Hunter):
         return None
 
     def get_pods(self, namespace=None):
+        config = get_config()
         pods = []
         try:
             if not namespace:
@@ -340,6 +343,7 @@ class AccessApiServerActive(ActiveHunter):
         self.path = f"{self.event.protocol}://{self.event.host}:{self.event.port}"
 
     def create_item(self, path, data):
+        config = get_config()
         headers = {"Content-Type": "application/json"}
         if self.event.auth_token:
             headers["Authorization"] = f"Bearer {self.event.auth_token}"
@@ -354,6 +358,7 @@ class AccessApiServerActive(ActiveHunter):
         return None
 
     def patch_item(self, path, data):
+        config = get_config()
         headers = {"Content-Type": "application/json-patch+json"}
         if self.event.auth_token:
             headers["Authorization"] = f"Bearer {self.event.auth_token}"
@@ -369,6 +374,7 @@ class AccessApiServerActive(ActiveHunter):
         return None
 
     def delete_item(self, path):
+        config = get_config()
         headers = {}
         if self.event.auth_token:
             headers["Authorization"] = f"Bearer {self.event.auth_token}"
@@ -570,6 +576,7 @@ class ApiVersionHunter(Hunter):
             self.session.headers.update({"Authorization": f"Bearer {self.event.auth_token}"})
 
     def execute(self):
+        config = get_config()
         if self.event.auth_token:
             logger.debug(
                 "Trying to access the API server version endpoint using pod's"

--- a/kube_hunter/modules/hunting/arp.py
+++ b/kube_hunter/modules/hunting/arp.py
@@ -2,7 +2,7 @@ import logging
 
 from scapy.all import ARP, IP, ICMP, Ether, sr1, srp
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, Vulnerability
 from kube_hunter.core.types import ActiveHunter, KubernetesCluster, IdentityTheft
@@ -32,6 +32,7 @@ class ArpSpoofHunter(ActiveHunter):
         self.event = event
 
     def try_getting_mac(self, ip):
+        config = get_config()
         ans = sr1(ARP(op=1, pdst=ip), timeout=config.network_timeout, verbose=0)
         return ans[ARP].hwsrc if ans else None
 
@@ -51,6 +52,7 @@ class ArpSpoofHunter(ActiveHunter):
         return False
 
     def execute(self):
+        config = get_config()
         self_ip = sr1(IP(dst="1.1.1.1", ttl=1) / ICMP(), verbose=0, timeout=config.network_timeout)[IP].dst
         arp_responses, _ = srp(
             Ether(dst="ff:ff:ff:ff:ff:ff") / ARP(op=1, pdst=f"{self_ip}/24"), timeout=config.netork_timeout, verbose=0,

--- a/kube_hunter/modules/hunting/certificates.py
+++ b/kube_hunter/modules/hunting/certificates.py
@@ -16,7 +16,7 @@ class CertificateEmail(Vulnerability, Event):
 
     def __init__(self, email):
         Vulnerability.__init__(
-            self, KubernetesCluster, "Certificate Includes Email Address", category=InformationDisclosure, khv="KHV021",
+            self, KubernetesCluster, "Certificate Includes Email Address", category=InformationDisclosure, vid="KHV021",
         )
         self.email = email
         self.evidence = "email: {}".format(self.email)

--- a/kube_hunter/modules/hunting/dashboard.py
+++ b/kube_hunter/modules/hunting/dashboard.py
@@ -2,7 +2,7 @@ import logging
 import json
 import requests
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.types import Hunter, RemoteCodeExec, KubernetesCluster
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Vulnerability, Event
@@ -31,6 +31,7 @@ class KubeDashboard(Hunter):
         self.event = event
 
     def get_nodes(self):
+        config = get_config()
         logger.debug("Passive hunter is attempting to get nodes types of the cluster")
         r = requests.get(f"http://{self.event.host}:{self.event.port}/api/v1/node", timeout=config.network_timeout)
         if r.status_code == 200 and "nodes" in r.text:

--- a/kube_hunter/modules/hunting/dns.py
+++ b/kube_hunter/modules/hunting/dns.py
@@ -3,7 +3,7 @@ import logging
 
 from scapy.all import IP, ICMP, UDP, DNS, DNSQR, ARP, Ether, sr1, srp1, srp
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, Vulnerability
 from kube_hunter.core.types import ActiveHunter, KubernetesCluster, IdentityTheft
@@ -36,6 +36,7 @@ class DnsSpoofHunter(ActiveHunter):
         self.event = event
 
     def get_cbr0_ip_mac(self):
+        config = get_config()
         res = srp1(Ether() / IP(dst="1.1.1.1", ttl=1) / ICMP(), verbose=0, timeout=config.network_timeout)
         return res[IP].src, res.src
 
@@ -47,6 +48,7 @@ class DnsSpoofHunter(ActiveHunter):
                 return match.group(1)
 
     def get_kube_dns_ip_mac(self):
+        config = get_config()
         kubedns_svc_ip = self.extract_nameserver_ip()
 
         # getting actual pod ip of kube-dns service, by comparing the src mac of a dns response and arp scanning.
@@ -66,6 +68,7 @@ class DnsSpoofHunter(ActiveHunter):
                 return response[ARP].psrc, response.src
 
     def execute(self):
+        config = get_config()
         logger.debug("Attempting to get kube-dns pod ip")
         self_ip = sr1(IP(dst="1.1.1.1", ttl=1) / ICMP(), verbose=0, timeout=config.netork_timeout)[IP].dst
         cbr0_ip, cbr0_mac = self.get_cbr0_ip_mac()

--- a/kube_hunter/modules/hunting/etcd.py
+++ b/kube_hunter/modules/hunting/etcd.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Vulnerability, Event, OpenPortEvent
 from kube_hunter.core.types import (
@@ -83,6 +83,7 @@ class EtcdRemoteAccessActive(ActiveHunter):
         self.write_evidence = ""
 
     def db_keys_write_access(self):
+        config = get_config()
         logger.debug(f"Trying to write keys remotely on host {self.event.host}")
         data = {"value": "remotely written data"}
         try:
@@ -115,6 +116,7 @@ class EtcdRemoteAccess(Hunter):
         self.protocol = "https"
 
     def db_keys_disclosure(self):
+        config = get_config()
         logger.debug(f"{self.event.host} Passive hunter is attempting to read etcd keys remotely")
         try:
             r = requests.get(
@@ -126,6 +128,7 @@ class EtcdRemoteAccess(Hunter):
             return False
 
     def version_disclosure(self):
+        config = get_config()
         logger.debug(f"Trying to check etcd version remotely at {self.event.host}")
         try:
             r = requests.get(
@@ -139,6 +142,7 @@ class EtcdRemoteAccess(Hunter):
             return False
 
     def insecure_access(self):
+        config = get_config()
         logger.debug(f"Trying to access etcd insecurely at {self.event.host}")
         try:
             r = requests.get(

--- a/kube_hunter/modules/hunting/kubelet.py
+++ b/kube_hunter/modules/hunting/kubelet.py
@@ -6,7 +6,7 @@ import re
 import requests
 import urllib3
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Vulnerability, Event, K8sVersionDisclosure
 from kube_hunter.core.types import (
@@ -25,9 +25,6 @@ from kube_hunter.modules.discovery.kubelet import (
 
 logger = logging.getLogger(__name__)
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
-
-""" Vulnerabilities """
 
 
 class ExposedPodsHandler(Vulnerability, Event):
@@ -187,6 +184,7 @@ class ReadOnlyKubeletPortHunter(Hunter):
         self.pods_endpoint_data = ""
 
     def get_k8s_version(self):
+        config = get_config()
         logger.debug("Passive hunter is attempting to find kubernetes version")
         metrics = requests.get(f"{self.path}/metrics", timeout=config.network_timeout).text
         for line in metrics.split("\n"):
@@ -208,12 +206,14 @@ class ReadOnlyKubeletPortHunter(Hunter):
         return privileged_containers if len(privileged_containers) > 0 else None
 
     def get_pods_endpoint(self):
+        config = get_config()
         logger.debug("Attempting to find pods endpoints")
         response = requests.get(f"{self.path}/pods", timeout=config.network_timeout)
         if "items" in response.text:
             return response.json()
 
     def check_healthz_endpoint(self):
+        config = get_config()
         r = requests.get(f"{self.path}/healthz", verify=False, timeout=config.network_timeout)
         return r.text if r.status_code == 200 else False
 
@@ -240,7 +240,7 @@ class SecureKubeletPortHunter(Hunter):
     Hunts specific endpoints on an open secured Kubelet
     """
 
-    class DebugHandlers(object):
+    class DebugHandlers:
         """ all methods will return the handler name if successful """
 
         def __init__(self, path, pod, session=None):
@@ -250,6 +250,7 @@ class SecureKubeletPortHunter(Hunter):
 
         # outputs logs from a specific container
         def test_container_logs(self):
+            config = get_config()
             logs_url = self.path + KubeletHandlers.CONTAINERLOGS.value.format(
                 pod_namespace=self.pod["namespace"], pod_id=self.pod["name"], container_name=self.pod["container"],
             )
@@ -257,6 +258,7 @@ class SecureKubeletPortHunter(Hunter):
 
         # need further investigation on websockets protocol for further implementation
         def test_exec_container(self):
+            config = get_config()
             # opens a stream to connect to using a web socket
             headers = {"X-Stream-Protocol-Version": "v2.channel.k8s.io"}
             exec_url = self.path + KubeletHandlers.EXEC.value.format(
@@ -274,6 +276,7 @@ class SecureKubeletPortHunter(Hunter):
 
         # need further investigation on websockets protocol for further implementation
         def test_port_forward(self):
+            config = get_config()
             headers = {
                 "Upgrade": "websocket",
                 "Connection": "Upgrade",
@@ -291,6 +294,7 @@ class SecureKubeletPortHunter(Hunter):
 
         # executes one command and returns output
         def test_run_container(self):
+            config = get_config()
             run_url = self.path + KubeletHandlers.RUN.value.format(
                 pod_namespace="test", pod_id="test", container_name="test", cmd="",
             )
@@ -299,12 +303,14 @@ class SecureKubeletPortHunter(Hunter):
 
         # returns list of currently running pods
         def test_running_pods(self):
+            config = get_config()
             pods_url = self.path + KubeletHandlers.RUNNINGPODS.value
             r = self.session.get(pods_url, verify=False, timeout=config.network_timeout)
             return r.json() if r.status_code == 200 else False
 
         # need further investigation on the differences between attach and exec
         def test_attach_container(self):
+            config = get_config()
             # headers={"X-Stream-Protocol-Version": "v2.channel.k8s.io"}
             attach_url = self.path + KubeletHandlers.ATTACH.value.format(
                 pod_namespace=self.pod["namespace"],
@@ -321,6 +327,7 @@ class SecureKubeletPortHunter(Hunter):
 
         # checks access to logs endpoint
         def test_logs_endpoint(self):
+            config = get_config()
             logs_url = self.session.get(
                 self.path + KubeletHandlers.LOGS.value.format(path=""), timeout=config.network_timeout,
             ).text
@@ -328,6 +335,7 @@ class SecureKubeletPortHunter(Hunter):
 
         # returns the cmd line used to run the kubelet
         def test_pprof_cmdline(self):
+            config = get_config()
             cmd = self.session.get(
                 self.path + KubeletHandlers.PPROF_CMDLINE.value, verify=False, timeout=config.network_timeout,
             )
@@ -350,11 +358,13 @@ class SecureKubeletPortHunter(Hunter):
         self.pods_endpoint_data = ""
 
     def get_pods_endpoint(self):
+        config = get_config()
         response = self.session.get(f"{self.path}/pods", verify=False, timeout=config.network_timeout)
         if "items" in response.text:
             return response.json()
 
     def check_healthz_endpoint(self):
+        config = get_config()
         r = requests.get(f"{self.path}/healthz", verify=False, timeout=config.network_timeout)
         return r.text if r.status_code == 200 else False
 
@@ -371,6 +381,7 @@ class SecureKubeletPortHunter(Hunter):
         self.test_handlers()
 
     def test_handlers(self):
+        config = get_config()
         # if kube-hunter runs in a pod, we test with kube-hunter's pod
         pod = self.kubehunter_pod if config.pod else self.get_random_pod()
         if pod:
@@ -434,6 +445,7 @@ class ProveRunHandler(ActiveHunter):
         self.base_path = f"https://{self.event.host}:{self.event.port}"
 
     def run(self, command, container):
+        config = get_config()
         run_url = KubeletHandlers.RUN.value.format(
             pod_namespace=container["namespace"],
             pod_id=container["pod"],
@@ -445,6 +457,7 @@ class ProveRunHandler(ActiveHunter):
         ).text
 
     def execute(self):
+        config = get_config()
         r = self.event.session.get(
             self.base_path + KubeletHandlers.PODS.value, verify=False, timeout=config.network_timeout,
         )
@@ -478,6 +491,7 @@ class ProveContainerLogsHandler(ActiveHunter):
         self.base_url = f"{protocol}://{self.event.host}:{self.event.port}/"
 
     def execute(self):
+        config = get_config()
         pods_raw = self.event.session.get(
             self.base_url + KubeletHandlers.PODS.value, verify=False, timeout=config.network_timeout,
         ).text
@@ -513,6 +527,7 @@ class ProveSystemLogs(ActiveHunter):
         self.base_url = f"https://{self.event.host}:{self.event.port}"
 
     def execute(self):
+        config = get_config()
         audit_logs = self.event.session.get(
             f"{self.base_url}/" + KubeletHandlers.LOGS.value.format(path="audit/audit.log"),
             verify=False,

--- a/kube_hunter/modules/hunting/mounts.py
+++ b/kube_hunter/modules/hunting/mounts.py
@@ -2,7 +2,7 @@ import logging
 import re
 import uuid
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, Vulnerability
 from kube_hunter.core.types import (
@@ -88,6 +88,7 @@ class ProveVarLogMount(ActiveHunter):
 
     # TODO: replace with multiple subscription to WriteMountToVarLog as well
     def get_varlog_mounters(self):
+        config = get_config()
         logger.debug("accessing /pods manually on ProveVarLogMount")
         pods = self.event.session.get(
             f"{self.base_path}/" + KubeletHandlers.PODS.value, verify=False, timeout=config.network_timeout,
@@ -107,6 +108,7 @@ class ProveVarLogMount(ActiveHunter):
 
     def traverse_read(self, host_file, container, mount_path, host_path):
         """Returns content of file on the host, and cleans trails"""
+        config = get_config()
         symlink_name = str(uuid.uuid4())
         # creating symlink to file
         self.run(f"ln -s {host_file} {mount_path}/{symlink_name}", container)

--- a/kube_hunter/modules/hunting/proxy.py
+++ b/kube_hunter/modules/hunting/proxy.py
@@ -3,7 +3,7 @@ import requests
 
 from enum import Enum
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Event, Vulnerability, K8sVersionDisclosure
 from kube_hunter.core.types import (
@@ -53,11 +53,13 @@ class KubeProxy(Hunter):
 
     @property
     def namespaces(self):
+        config = get_config()
         resource_json = requests.get(f"{self.api_url}/namespaces", timeout=config.network_timeout).json()
         return self.extract_names(resource_json)
 
     @property
     def services(self):
+        config = get_config()
         # map between namespaces and service names
         services = dict()
         for namespace in self.namespaces:
@@ -85,6 +87,7 @@ class ProveProxyExposed(ActiveHunter):
         self.event = event
 
     def execute(self):
+        config = get_config()
         version_metadata = requests.get(
             f"http://{self.event.host}:{self.event.port}/version", verify=False, timeout=config.network_timeout,
         ).json()
@@ -102,6 +105,7 @@ class K8sVersionDisclosureProve(ActiveHunter):
         self.event = event
 
     def execute(self):
+        config = get_config()
         version_metadata = requests.get(
             f"http://{self.event.host}:{self.event.port}/version", verify=False, timeout=config.network_timeout,
         ).json()

--- a/kube_hunter/modules/hunting/secrets.py
+++ b/kube_hunter/modules/hunting/secrets.py
@@ -50,7 +50,7 @@ class AccessSecrets(Hunter):
         for dirname, _, files in os.walk("/var/run/secrets/"):
             for f in files:
                 self.secrets_evidence.append(os.path.join(dirname, f))
-        return True if (len(self.secrets_evidence) > 0) else False
+        return len(self.secrets_evidence) > 0
 
     def execute(self):
         if self.event.auth_token is not None:

--- a/kube_hunter/modules/report/__init__.py
+++ b/kube_hunter/modules/report/__init__.py
@@ -1,3 +1,2 @@
+# flake8: noqa: E402
 from kube_hunter.modules.report.factory import get_reporter, get_dispatcher
-
-__all__ = [get_reporter, get_dispatcher]

--- a/kube_hunter/modules/report/base.py
+++ b/kube_hunter/modules/report/base.py
@@ -8,7 +8,7 @@ from kube_hunter.modules.report.collector import (
 )
 
 
-class BaseReporter(object):
+class BaseReporter:
     def get_nodes(self):
         nodes = list()
         node_locations = set()

--- a/kube_hunter/modules/report/collector.py
+++ b/kube_hunter/modules/report/collector.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 
-from kube_hunter.conf import config
+from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import (
     Event,
@@ -14,20 +14,16 @@ from kube_hunter.core.events.types import (
 
 logger = logging.getLogger(__name__)
 
-global services_lock
 services_lock = threading.Lock()
 services = list()
-
-global vulnerabilities_lock
 vulnerabilities_lock = threading.Lock()
 vulnerabilities = list()
-
 hunters = handler.all_hunters
 
 
 @handler.subscribe(Service)
 @handler.subscribe(Vulnerability)
-class Collector(object):
+class Collector:
     def __init__(self, event=None):
         self.event = event
 
@@ -51,11 +47,12 @@ class TablesPrinted(Event):
 
 
 @handler.subscribe(HuntFinished)
-class SendFullReport(object):
+class SendFullReport:
     def __init__(self, event):
         self.event = event
 
     def execute(self):
+        config = get_config()
         report = config.reporter.get_report(statistics=config.statistics, mapping=config.mapping)
         config.dispatcher.dispatch(report)
         handler.publish_event(ReportDispatched())
@@ -63,7 +60,7 @@ class SendFullReport(object):
 
 
 @handler.subscribe(HuntStarted)
-class StartedInfo(object):
+class StartedInfo:
     def __init__(self, event):
         self.event = event
 

--- a/kube_hunter/modules/report/dispatchers.py
+++ b/kube_hunter/modules/report/dispatchers.py
@@ -5,7 +5,7 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-class HTTPDispatcher(object):
+class HTTPDispatcher:
     def dispatch(self, report):
         logger.debug("Dispatching report via HTTP")
         dispatch_method = os.environ.get("KUBEHUNTER_HTTP_DISPATCH_METHOD", "POST").upper()
@@ -24,7 +24,7 @@ class HTTPDispatcher(object):
             logger.exception(f"Could not dispatch report to {dispatch_url}")
 
 
-class STDOUTDispatcher(object):
+class STDOUTDispatcher:
     def dispatch(self, report):
         logger.debug("Dispatching report via stdout")
         print(report)

--- a/kube_hunter/modules/report/factory.py
+++ b/kube_hunter/modules/report/factory.py
@@ -1,9 +1,9 @@
+import logging
+
 from kube_hunter.modules.report.json import JSONReporter
 from kube_hunter.modules.report.yaml import YAMLReporter
 from kube_hunter.modules.report.plain import PlainReporter
 from kube_hunter.modules.report.dispatchers import STDOUTDispatcher, HTTPDispatcher
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/kube_hunter/modules/report/json.py
+++ b/kube_hunter/modules/report/json.py
@@ -1,4 +1,5 @@
 import json
+
 from kube_hunter.modules.report.base import BaseReporter
 
 

--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from prettytable import ALL, PrettyTable
 
 from kube_hunter.modules.report.base import BaseReporter
@@ -46,7 +44,6 @@ class PlainReporter(BaseReporter):
             if vulnerabilities_len:
                 output += self.vulns_table()
             output += "\nKube Hunter couldn't find any clusters"
-            # print("\nKube Hunter couldn't find any clusters. {}".format("Maybe try with --active?" if not config.active else ""))
         return output
 
     def nodes_table(self):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ staticx
 black
 pre-commit
 flake8-bugbear
+flake8-mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     ruamel.yaml
     future
     packaging
+    dataclasses
 setup_requires =
     setuptools>=30.3.0
     setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from subprocess import check_call
-from pkg_resources import parse_requirements
 from configparser import ConfigParser
+from pkg_resources import parse_requirements
+from subprocess import check_call
+from typing import Any, List
 from setuptools import setup, Command
 
 
@@ -8,7 +9,7 @@ class ListDependenciesCommand(Command):
     """A custom command to list dependencies"""
 
     description = "list package dependencies"
-    user_options = []
+    user_options: List[Any] = []
 
     def initialize_options(self):
         pass
@@ -27,7 +28,7 @@ class PyInstallerCommand(Command):
     """A custom command to run PyInstaller to build standalone executable."""
 
     description = "run PyInstaller on kube-hunter entrypoint"
-    user_options = []
+    user_options: List[Any] = []
 
     def initialize_options(self):
         pass

--- a/tests/core/test_cloud.py
+++ b/tests/core/test_cloud.py
@@ -1,12 +1,16 @@
 import requests_mock
 import json
 
+from kube_hunter.conf import Config, set_config
 from kube_hunter.core.events.types import NewHostEvent
 
+set_config(Config())
 
-# Testing if it doesn't try to run get_cloud if the cloud type is already set.
-# get_cloud(1.2.3.4) will result with an error
+
 def test_presetcloud():
+    """ Testing if it doesn't try to run get_cloud if the cloud type is already set.
+    get_cloud(1.2.3.4) will result with an error
+    """
     expcted = "AWS"
     hostEvent = NewHostEvent(host="1.2.3.4", cloud=expcted)
     assert expcted == hostEvent.cloud

--- a/tests/core/test_handler.py
+++ b/tests/core/test_handler.py
@@ -1,8 +1,8 @@
 # flake8: noqa: E402
 
-from kube_hunter.conf import config
+from kube_hunter.conf import Config, set_config
 
-config.active = True
+set_config(Config(active=True))
 
 from kube_hunter.core.events.handler import handler
 from kube_hunter.modules.discovery.apiserver import ApiServiceDiscovery

--- a/tests/core/test_subscribe.py
+++ b/tests/core/test_subscribe.py
@@ -1,10 +1,12 @@
 import time
 
+from kube_hunter.conf import Config, set_config
 from kube_hunter.core.types import Hunter
 from kube_hunter.core.events.types import Event, Service
 from kube_hunter.core.events import handler
 
 counter = 0
+set_config(Config())
 
 
 class OnceOnlyEvent(Service, Event):

--- a/tests/discovery/test_apiserver.py
+++ b/tests/discovery/test_apiserver.py
@@ -1,5 +1,10 @@
+# flake8: noqa: E402
 import requests_mock
 import time
+
+from kube_hunter.conf import Config, set_config
+
+set_config(Config())
 
 from kube_hunter.modules.discovery.apiserver import ApiServer, ApiServiceDiscovery
 from kube_hunter.core.events.types import Event

--- a/tests/discovery/test_hosts.py
+++ b/tests/discovery/test_hosts.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E402
 import json
 import requests_mock
 import pytest
@@ -5,6 +6,9 @@ import pytest
 from netaddr import IPNetwork, IPAddress
 from typing import List
 from kube_hunter.conf import Config, get_config, set_config
+
+set_config(Config())
+
 from kube_hunter.core.events import handler
 from kube_hunter.core.types import Hunter
 from kube_hunter.modules.discovery.hosts import (
@@ -61,7 +65,7 @@ class TestFromPodHostDiscovery:
 
 
 @handler.subscribe(HostScanEvent)
-class TestHostDiscovery(Hunter):
+class HunterTestHostDiscovery(Hunter):
     """TestHostDiscovery
     In this set of tests we should only trigger HostScanEvent when remote or cidr are set
     """

--- a/tests/hunting/test_apiserver_hunter.py
+++ b/tests/hunting/test_apiserver_hunter.py
@@ -1,5 +1,10 @@
+# flake8: noqa: E402
 import requests_mock
 import time
+
+from kube_hunter.conf import Config, set_config
+
+set_config(Config())
 
 from kube_hunter.modules.hunting.apiserver import (
     AccessApiServer,

--- a/tests/hunting/test_cvehunting.py
+++ b/tests/hunting/test_cvehunting.py
@@ -1,4 +1,9 @@
+# flake8: noqa: E402
 import time
+
+from kube_hunter.conf import Config, set_config
+
+set_config(Config())
 
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import K8sVersionDisclosure

--- a/tests/hunting/test_dashboard.py
+++ b/tests/hunting/test_dashboard.py
@@ -2,7 +2,11 @@ import json
 
 from types import SimpleNamespace
 from requests_mock import Mocker
-from kube_hunter.modules.hunting.dashboard import KubeDashboard
+from kube_hunter.conf import Config, set_config
+
+set_config(Config())
+
+from kube_hunter.modules.hunting.dashboard import KubeDashboard  # noqa: E402
 
 
 class TestKubeDashboard:

--- a/tests/modules/test_reports.py
+++ b/tests/modules/test_reports.py
@@ -1,3 +1,8 @@
+# flake8: noqa: E402
+from kube_hunter.conf import Config, set_config
+
+set_config(Config())
+
 from kube_hunter.modules.report import get_reporter, get_dispatcher
 from kube_hunter.modules.report.factory import (
     YAMLReporter,


### PR DESCRIPTION
## Description
Enable using config without triggering argparse.
Add linting with mypy in order to catch more kinds of bugs (especially usage of not existing properties). 

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues
Resolves #341 

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

## Contribution checklist
 - [X] I have read the Contributing Guidelines.
 - [X] The commits refer to an active issue in the repository.
 - [X] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
