### PR TITLE
Fix CertificateDiscovery hunter for Python3

### DIFF
--- a/kube_hunter/modules/hunting/certificates.py
+++ b/kube_hunter/modules/hunting/certificates.py
@@ -8,7 +8,7 @@ from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import Vulnerability, Event, Service
 
 logger = logging.getLogger(__name__)
-email_pattern = re.compile(r"([a-z0-9]+@[a-z0-9]+\.[a-z0-9]+)")
+email_pattern = re.compile(rb"([a-z0-9]+@[a-z0-9]+\.[a-z0-9]+)")
 
 
 class CertificateEmail(Vulnerability, Event):
@@ -39,8 +39,11 @@ class CertificateDiscovery(Hunter):
         except ssl.SSLError:
             # If the server doesn't offer SSL on this port we won't get a certificate
             return
+        self.examine_certificate(cert)
+
+    def examine_certificate(self, cert):
         c = cert.strip(ssl.PEM_HEADER).strip(ssl.PEM_FOOTER)
-        certdata = base64.decodebytes(c)
+        certdata = base64.b64decode(c)
         emails = re.findall(email_pattern, certdata)
         for email in emails:
             self.publish_event(CertificateEmail(email=email))

--- a/tests/hunting/test_certificates.py
+++ b/tests/hunting/test_certificates.py
@@ -1,0 +1,41 @@
+from kube_hunter.conf import Config, set_config
+
+set_config(Config())
+
+from kube_hunter.core.events.types import Event
+from kube_hunter.modules.hunting.certificates import CertificateDiscovery, CertificateEmail
+from kube_hunter.core.events import handler
+
+def test_CertificateDiscovery():
+    cert = """
+    -----BEGIN CERTIFICATE-----
+MIIDZDCCAkwCCQCAzfCLqrJvuTANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJV
+UzELMAkGA1UECAwCQ0ExEDAOBgNVBAoMB05vZGUuanMxETAPBgNVBAsMCG5vZGUt
+Z3lwMRIwEAYDVQQDDAlsb2NhbGhvc3QxHzAdBgkqhkiG9w0BCQEWEGJ1aWxkQG5v
+ZGVqcy5vcmcwHhcNMTkwNjIyMDYyMjMzWhcNMjIwNDExMDYyMjMzWjB0MQswCQYD
+VQQGEwJVUzELMAkGA1UECAwCQ0ExEDAOBgNVBAoMB05vZGUuanMxETAPBgNVBAsM
+CG5vZGUtZ3lwMRIwEAYDVQQDDAlsb2NhbGhvc3QxHzAdBgkqhkiG9w0BCQEWEGJ1
+aWxkQG5vZGVqcy5vcmcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDS
+CHjvtVW4HdbbUwZ/ZV9s6U4x0KSoyNQrsCZjB8kRpFPe50DS5mfmu2SNBGYKRgzk
+4QEEwFB9N2o8YTWsCefSRl6ti4ToPZqulU4hhRKYrEGtMJcRzi3IN7s200JaO3UH
+01Su8ruO0NESb5zEU1Ykfh8Lub8TGEAINmgI61d/5d5Aq3kDjUHQJt1Ekw03Ylnu
+juQyCGZxLxnngu0mIvwzyL/UeeUgsfQLzvppUk6In7tC1zzMjSPWo0c8qu6KvrW4
+bKYnkZkzdQifzbpO5ERMEsh5HWq0uHa6+dgcVHFvlhdqF4Uat87ygNplVf0txsZB
+MNVqbz1k6xkZYMnzDoydAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADspZGtKpWxy
+J1W3FA1aeQhMvequQTcMRz4avkm4K4HfTdV1iVD4CbvdezBphouBlyLVLDFJP7RZ
+m7dBJVgBwnxufoFLne8cR2MGqDRoySbFT1AtDJdxabE6Fg+QGUpgOQfeBJ6ANlSB
++qJ+HG4QA+Ouh5hxz9mgYwkIsMUABHiwENdZ/kT8Edw4xKgd3uH0YP4iiePMD66c
+rzW3uXH5J1jnKgBlpxtog4P6dHCcoq+PZJ17W5bdXNyqC1LPzQqniZ2BNcEZ4ix3
+slAZAOWD1zLLGJhBPMV1fa0sHNBWc6oicr3YK/IDb0cp9kiLvnUu1pHy+LWQGqtC
+rceJuGsnJEQ=
+-----END CERTIFICATE-----
+"""
+    c = CertificateDiscovery(Event())
+    c.examine_certificate(cert)
+
+@handler.subscribe(CertificateEmail)
+class test_CertificateEmail(object):
+    def __init__(self, event):
+        assert event.email == b"build@nodejs.org0"
+
+

--- a/tests/hunting/test_certificates.py
+++ b/tests/hunting/test_certificates.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E402
 from kube_hunter.conf import Config, set_config
 
 set_config(Config())
@@ -5,6 +6,7 @@ set_config(Config())
 from kube_hunter.core.events.types import Event
 from kube_hunter.modules.hunting.certificates import CertificateDiscovery, CertificateEmail
 from kube_hunter.core.events import handler
+
 
 def test_CertificateDiscovery():
     cert = """
@@ -33,9 +35,8 @@ rceJuGsnJEQ=
     c = CertificateDiscovery(Event())
     c.examine_certificate(cert)
 
+
 @handler.subscribe(CertificateEmail)
 class test_CertificateEmail(object):
     def __init__(self, event):
         assert event.email == b"build@nodejs.org0"
-
-


### PR DESCRIPTION
## Description

Python3 is more picky about bytes vs strings than Python2, and this was causing errors in the CertificateDiscovery hunter

## Fixed Issues

Fixes #349 

## "BEFORE" and "AFTER" output

See #349 for debug logs that this fix resolves

## Contribution checklist
 - [X] I have read the Contributing Guidelines.
 - [X] The commits refer to an active issue in the repository.
 - [X] I have added automated testing to cover this case.
 
