### PR TITLE
Fix: Removed an unnecessary f-string causing linting problem

### DIFF
--- a/kube_hunter/core/events/types.py
+++ b/kube_hunter/core/events/types.py
@@ -148,7 +148,7 @@ class NewHostEvent(Event):
             ).json()
             return result["cloud"] or "NoCloud"
         except requests.ConnectionError:
-            logger.info(f"Failed to connect cloud type service", exc_info=True)
+            logger.info("Failed to connect cloud type service", exc_info=True)
         except Exception:
             logger.warning(f"Unable to check cloud of {self.host}", exc_info=True)
         return "NoCloud"


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
An unnecessary f-string appeared in an info logging message, which caused CI to fail on linting

## Fixed Issues
Removed the f-string, changed to normal string. no issue regarding this.
related #354 

## "BEFORE" and "AFTER" output

### BEFORE
```bash
$ make lint-check
flake8
./kube_hunter/core/events/types.py:151:25: F541 f-string is missing placeholders
Makefile:29: recipe for target 'lint-check' failed
make: *** [lint-check] Error 1
```

### AFTER
No Errors


## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
