### PR TITLE
Added External Plugins Support

### DIFF
--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -1,1 +1,1 @@
-kube_hunter / __main__.py
+kube_hunter/__main__.py

--- a/kube-hunter.py
+++ b/kube-hunter.py
@@ -1,1 +1,1 @@
-kube_hunter/__main__.py
+kube_hunter / __main__.py

--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -28,7 +28,7 @@ config = Config(
 setup_logger(args.log)
 set_config(config)
 
-# Running all other registered plugins before execution 
+# Running all other registered plugins before execution
 pm.hook.load_plugin(args=args)
 
 from kube_hunter.core.events import handler

--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -4,11 +4,15 @@
 import logging
 import threading
 
-from kube_hunter.conf import Config, set_config
+from kube_hunter.conf import Config, set_config, add_config
 from kube_hunter.conf.parser import parse_args
 from kube_hunter.conf.logging import setup_logger
 
-args = parse_args()
+from kube_hunter.plugins import initialize_plugin_manager
+
+pm = initialize_plugin_manager()
+# Using a plugin hook for adding arguments before parsing
+args = parse_args(add_args_hook=pm.hook.parser_add_arguments)
 config = Config(
     active=args.active,
     cidr=args.cidr,
@@ -23,6 +27,9 @@ config = Config(
 )
 setup_logger(args.log)
 set_config(config)
+
+# Running all other registered plugins before execution 
+pm.hook.load_plugin(args=args)
 
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import HuntFinished, HuntStarted

--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -4,7 +4,7 @@
 import logging
 import threading
 
-from kube_hunter.conf import Config, set_config, add_config
+from kube_hunter.conf import Config, set_config
 from kube_hunter.conf.parser import parse_args
 from kube_hunter.conf.logging import setup_logger
 

--- a/kube_hunter/conf/parser.py
+++ b/kube_hunter/conf/parser.py
@@ -1,9 +1,13 @@
 from argparse import ArgumentParser
+from kube_hunter.plugins import hookimpl
 
 
-def parse_args():
-    parser = ArgumentParser(description="kube-hunter - hunt for security weaknesses in Kubernetes clusters")
-
+@hookimpl
+def parser_add_arguments(parser):
+    """
+    This is the default hook implementation for parse_add_argument
+    Contains initialization for all default arguments
+    """
     parser.add_argument(
         "--list", action="store_true", help="Displays all tests in kubehunter (add --active flag to see active tests)",
     )
@@ -58,6 +62,18 @@ def parse_args():
     parser.add_argument("--statistics", action="store_true", help="Show hunting statistics")
 
     parser.add_argument("--network-timeout", type=float, default=5.0, help="network operations timeout")
+
+
+def parse_args(add_args_hook):
+    """
+    Function handles all argument parsing
+
+    @param add_arguments: hook for adding arguments to it's given ArgumentParser parameter
+    @return: parsed arguments dict
+    """
+    parser = ArgumentParser(description="kube-hunter - hunt for security weaknesses in Kubernetes clusters")
+    # adding all arguments to the parser
+    add_args_hook(parser=parser)
 
     args = parser.parse_args()
     if args.cidr:

--- a/kube_hunter/plugins/__init__.py
+++ b/kube_hunter/plugins/__init__.py
@@ -1,0 +1,21 @@
+import pluggy
+
+from kube_hunter.plugins import hookspecs
+from kube_hunter.conf import parser
+
+hookimpl = pluggy.HookimplMarker("kube-hunter")
+
+
+def initialize_plugin_manager():
+    """
+    Initializes and loads all default and setup implementations for registered plugins
+
+    @return: initialized plugin manager
+    """
+    pm = pluggy.PluginManager("kube-hunter")
+    pm.add_hookspecs(hookspecs)
+    pm.load_setuptools_entrypoints("kube_hunter")
+
+    # default registration of builtin implemented plugins
+    pm.register(parser)
+    return pm

--- a/kube_hunter/plugins/__init__.py
+++ b/kube_hunter/plugins/__init__.py
@@ -18,5 +18,5 @@ def initialize_plugin_manager():
     # default registration of builtin implemented plugins
     from kube_hunter.conf import parser
     pm.register(parser)
-    
+
     return pm

--- a/kube_hunter/plugins/__init__.py
+++ b/kube_hunter/plugins/__init__.py
@@ -1,7 +1,6 @@
 import pluggy
 
 from kube_hunter.plugins import hookspecs
-from kube_hunter.conf import parser
 
 hookimpl = pluggy.HookimplMarker("kube-hunter")
 
@@ -17,5 +16,7 @@ def initialize_plugin_manager():
     pm.load_setuptools_entrypoints("kube_hunter")
 
     # default registration of builtin implemented plugins
+    from kube_hunter.conf import parser
     pm.register(parser)
+    
     return pm

--- a/kube_hunter/plugins/__init__.py
+++ b/kube_hunter/plugins/__init__.py
@@ -17,6 +17,7 @@ def initialize_plugin_manager():
 
     # default registration of builtin implemented plugins
     from kube_hunter.conf import parser
+
     pm.register(parser)
 
     return pm

--- a/kube_hunter/plugins/hookspecs.py
+++ b/kube_hunter/plugins/hookspecs.py
@@ -1,0 +1,24 @@
+import pluggy
+from argparse import ArgumentParser
+
+hookspec = pluggy.HookspecMarker("kube-hunter")
+
+
+@hookspec
+def parser_add_arguments(parser: ArgumentParser):
+    """Add arguments to the ArgumentParser.
+
+    If a plugin requires an aditional argument, it should implement this hook
+    and add the argument to the Argument Parser
+
+    @param parser: an ArgumentParser, calls parser.add_argument on it
+    """
+
+
+@hookspec
+def load_plugin(args):
+    """Plugins that wish to execute code after the argument parsing
+    should implement this hook.
+
+    @param args: all parsed arguments passed to kube-hunter
+    """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ black
 pre-commit
 flake8-bugbear
 flake8-mypy
+pluggy

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     future
     packaging
     dataclasses
+    pluggy
 setup_requires =
     setuptools>=30.3.0
     setuptools_scm

--- a/tests/plugins/test_hooks.py
+++ b/tests/plugins/test_hooks.py
@@ -1,0 +1,13 @@
+from kube_hunter.plugins import hookimpl
+
+return_string = "return_string"
+
+
+@hookimpl
+def parser_add_arguments(parser):
+    return return_string
+
+
+@hookimpl
+def load_plugin(args):
+    return return_string

--- a/tests/plugins/test_plugins_hooks.py
+++ b/tests/plugins/test_plugins_hooks.py
@@ -1,0 +1,17 @@
+from argparse import ArgumentParser
+from tests.plugins import test_hooks
+from kube_hunter.plugins import initialize_plugin_manager
+
+
+def test_all_plugin_hooks():
+    pm = initialize_plugin_manager()
+    pm.register(test_hooks)
+
+    # Testing parser_add_arguments
+    parser = ArgumentParser("Test Argument Parser")
+    results = pm.hook.parser_add_arguments(parser=parser)
+    assert test_hooks.return_string in results
+
+    # Testing load_plugin
+    results = pm.hook.load_plugin(args=[])
+    assert test_hooks.return_string in results


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Officially added support for plugins to be loaded. 
By using [Pluggy](https://pypi.org/project/pluggy/)

The hook specifications are centered at:
`kube_hunter/plugins/hookspecs.py`

In order to implement your plugin, use the `hookimpl` decorator from `kube_hunter.plugins`
and implement one of the following:
* `parser_add_arguments` - Add an argument
* `load_plugin` - Run code right after argument parsing

To load your plugin module you should install your package like this:
```python
from setuptools import setup

setup(
    name="kube-hunter-mypackage",
    install_requires="kube-hunter",
    entry_points={"kube_hunter": ["mypackage = my_module"]},
    py_modules=["my_module"],
)
```
Current functionality was not impacted.

Main changes in the code:
* changed the argument parsing mechanism, the old function is now registered as a hook for the parsing steps, and receives an already initialized `ArgumentParser` object
* load_plugin is called, essentially calls all registered plugins, passing them the parsed args object, so they can have access to their custom argument. (which is not at the main static Config object)

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues
closes #321 

## "BEFORE" and "AFTER" output

### BEFORE

### AFTER

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
