### PR TITLE
Added multistage build for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,8 @@ RUN make deps
 COPY . .
 RUN make install
 
+FROM python:3.8-alpine
+COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
+COPY --from=builder /usr/local/bin/kube-hunter /usr/local/bin/kube-hunter
+
 ENTRYPOINT ["kube-hunter"]


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Until now we used alot of unnecessary alpine packages in the final image.
Now we only use the site-packages directory and the kube-hunter installed binary on a python alpine base image

## Fixed Issues

This removes vulnerabilities found in kube-hunter image. as well as reduce size from 300MB~ to 77MB!

## Contribution checklist
 - [ ] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
