### PR TITLE
Fixed typo in DNS hunting

### DIFF
--- a/kube_hunter/modules/hunting/dns.py
+++ b/kube_hunter/modules/hunting/dns.py
@@ -70,7 +70,7 @@ class DnsSpoofHunter(ActiveHunter):
     def execute(self):
         config = get_config()
         logger.debug("Attempting to get kube-dns pod ip")
-        self_ip = sr1(IP(dst="1.1.1.1", ttl=1) / ICMP(), verbose=0, timeout=config.netork_timeout)[IP].dst
+        self_ip = sr1(IP(dst="1.1.1.1", ttl=1) / ICMP(), verbose=0, timeout=config.network_timeout)[IP].dst
         cbr0_ip, cbr0_mac = self.get_cbr0_ip_mac()
 
         kubedns = self.get_kube_dns_ip_mac()


### PR DESCRIPTION
## Description
This fixes a crash due to a typo in Kube-DNS hunting when using the network timeout option.


## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
