### PR TITLE
Fixed bug in etcd hunting

### DIFF
--- a/kube_hunter/modules/hunting/etcd.py
+++ b/kube_hunter/modules/hunting/etcd.py
@@ -157,10 +157,10 @@ class EtcdRemoteAccess(Hunter):
 
     def execute(self):
         if self.insecure_access():  # make a decision between http and https protocol
-            self.protocol = "http"
+            self.event.protocol = "http"
         if self.version_disclosure():
             self.publish_event(EtcdRemoteVersionDisclosureEvent(self.version_evidence))
-            if self.protocol == "http":
+            if self.event.protocol == "http":
                 self.publish_event(EtcdAccessEnabledWithoutAuthEvent(self.version_evidence))
             if self.db_keys_disclosure():
                 self.publish_event(EtcdRemoteReadAccessEvent(self.keys_evidence))

--- a/kube_hunter/modules/hunting/etcd.py
+++ b/kube_hunter/modules/hunting/etcd.py
@@ -135,7 +135,7 @@ class EtcdRemoteAccess(Hunter):
         logger.debug(f"Trying to check etcd version remotely at {self.event.host}")
         try:
             r = requests.get(
-                f"{self.protocol}://{self.event.host}:{ETCD_PORT}/version",
+                f"{self.event.protocol}://{self.event.host}:{ETCD_PORT}/version",
                 verify=False,
                 timeout=config.network_timeout,
             )


### PR DESCRIPTION
## Description
Etcd hunting was failing due to accessing an uninitialized protocol property of hunter.
Protocol property is set on events, this was a typo.

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.

