### PR TITLE
Fixed bug in certificate hunting

### DIFF
--- a/kube_hunter/modules/hunting/certificates.py
+++ b/kube_hunter/modules/hunting/certificates.py
@@ -42,7 +42,7 @@ class CertificateDiscovery(Hunter):
         self.examine_certificate(cert)
 
     def examine_certificate(self, cert):
-        c = cert.strip(ssl.PEM_HEADER).strip('\n').strip(ssl.PEM_FOOTER).strip('\n')
+        c = cert.strip(ssl.PEM_HEADER).strip("\n").strip(ssl.PEM_FOOTER).strip("\n")
         certdata = base64.b64decode(c)
         emails = re.findall(email_pattern, certdata)
         for email in emails:

--- a/kube_hunter/modules/hunting/certificates.py
+++ b/kube_hunter/modules/hunting/certificates.py
@@ -42,7 +42,7 @@ class CertificateDiscovery(Hunter):
         self.examine_certificate(cert)
 
     def examine_certificate(self, cert):
-        c = cert.strip(ssl.PEM_HEADER).strip(ssl.PEM_FOOTER)
+        c = cert.strip(ssl.PEM_HEADER).strip('\n').strip(ssl.PEM_FOOTER).strip('\n')
         certdata = base64.b64decode(c)
         emails = re.findall(email_pattern, certdata)
         for email in emails:


### PR DESCRIPTION
# Description
Certificate hunting was failing because of multiple newlines in certificates returns from ssl.get_server_certificate.
Essentially the PEM footer was not stripped, causing the b64decode to fail.

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 