### PR TITLE
Update job.yml for Kubernetes cluster jobs

### DIFF
--- a/job.yaml
+++ b/job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: kube-hunter
         image: aquasec/kube-hunter 
-        command: ["python", "kube-hunter.py"]
+        command: ["kube-hunter"]
         args: ["--pod"]
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
Existing job.yml has wrong command for command ["python", "kube-hunter,py"]. But it should change to command ["kube-hunter"]

<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Existing job.yml has command["python", "kube-hunter.py"] but it is not correct and once we deployed to k8s cluster, pods will Error state. Because the pods cannot find the correct command. So the command should be like this.
command["kube-hunter"]
I have changed the job.yml and updated the repo. 

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues

Please mention any issues fixed in the PR by referencing it properly in the commit message.
As per the convention, use appropriate keywords such as `fixes`, `closes`, `resolves` to automatically refer the issue.
Please consult [official github documentation](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) for details.

Fixes #(issue)

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

### BEFORE
Any Terminal Output Before Changes.

> Kube Pod Error State:
> kube-hunter-9gjjn                         0/1     Error     0          8m32s
> kube-hunter-bhxlq                         0/1     Error     0          8m16s
> kube-hunter-p5pkx                         0/1     Error     0          8m26s
> kube-hunter-srztm                         0/1     Error     0          7m16s
> kube-hunter-xt68b                         0/1     Error     0          7m56s

Pods Error logs: 

> python: can't open file 'kube-hunter.py': [Errno 2] No such file or directory

### AFTER
After changed job.yml and deployed. Then it worked as expected.

> kube-hunter-hhwh2                         1/1     Running   0          10s

Then started to hunt the vulnerabilities.

> 2020-08-24 08:11:25,696 INFO kube_hunter.modules.report.collector Started hunting
> 2020-08-24 08:11:25,697 INFO kube_hunter.modules.report.collector Discovering Open Kubernetes Services


## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [x] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
