### PR TITLE
Fix job.yaml

### DIFF
--- a/job.yaml
+++ b/job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: kube-hunter
         image: aquasec/kube-hunter 
-        command: ["python", "kube-hunter.py"]
+        command: ["/usr/local/bin/kube-hunter"]
         args: ["--pod"]
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
## Description
Current version produces the following error:
```
python: can't open file 'kube-hunter.py': [Errno 2] No such file or directory
```
This will change the command to use `kube-hunter` in the `/usr/local/bin` folder

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues

## "BEFORE" and "AFTER" output


### BEFORE


### AFTER


## Contribution checklist
 - [x ] I have read the Contributing Guidelines.
 - [-] The commits refer to an active issue in the repository.
 - [-] I have added automated testing to cover this case.
 
## Notes
Simple fix of the job.yaml
