### PR TITLE
Adding support for log redirection using --log-file option (#329)

### DIFF
--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -18,6 +18,7 @@ config = Config(
     cidr=args.cidr,
     include_patched_versions=args.include_patched_versions,
     interface=args.interface,
+    log_file=args.log_file,
     mapping=args.mapping,
     network_timeout=args.network_timeout,
     pod=args.pod,
@@ -25,7 +26,7 @@ config = Config(
     remote=args.remote,
     statistics=args.statistics,
 )
-setup_logger(args.log)
+setup_logger(args.log, args.log_file)
 set_config(config)
 
 # Running all other registered plugins before execution

--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -13,6 +13,7 @@ class Config:
     - interface: Interface scanning mode
     - list_hunters: Print a list of existing hunters
     - log_level: Log level
+    - log_file: Log File path
     - mapping: Report only found components
     - network_timeout: Timeout for network operations
     - pod: From pod scanning mode
@@ -27,6 +28,7 @@ class Config:
     dispatcher: Optional[Any] = None
     include_patched_versions: bool = False
     interface: bool = False
+    log_file: Optional[str] = None
     mapping: bool = False
     network_timeout: float = 5.0
     pod: bool = False

--- a/kube_hunter/conf/logging.py
+++ b/kube_hunter/conf/logging.py
@@ -1,6 +1,5 @@
 import logging
 
-
 DEFAULT_LEVEL = logging.INFO
 DEFAULT_LEVEL_NAME = logging.getLevelName(DEFAULT_LEVEL)
 LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
@@ -10,7 +9,7 @@ logging.getLogger("scapy.runtime").setLevel(logging.CRITICAL)
 logging.getLogger("scapy.loading").setLevel(logging.CRITICAL)
 
 
-def setup_logger(level_name):
+def setup_logger(level_name, logfile):
     # Remove any existing handlers
     # Unnecessary in Python 3.8 since `logging.basicConfig` has `force` parameter
     for h in logging.getLogger().handlers[:]:
@@ -22,6 +21,9 @@ def setup_logger(level_name):
     else:
         log_level = getattr(logging, level_name.upper(), None)
         log_level = log_level if isinstance(log_level, int) else None
-        logging.basicConfig(level=log_level or DEFAULT_LEVEL, format=LOG_FORMAT)
+        if logfile is None:
+            logging.basicConfig(level=log_level or DEFAULT_LEVEL, format=LOG_FORMAT)
+        else:
+            logging.basicConfig(filename=logfile, level=log_level or DEFAULT_LEVEL, format=LOG_FORMAT)
         if not log_level:
             logging.warning(f"Unknown log level '{level_name}', using {DEFAULT_LEVEL_NAME}")

--- a/kube_hunter/conf/parser.py
+++ b/kube_hunter/conf/parser.py
@@ -57,6 +57,13 @@ def parser_add_arguments(parser):
     )
 
     parser.add_argument(
+        "--log-file",
+        type=str,
+        default=None,
+        help="Path to a log file to output all logs to",
+    )
+
+    parser.add_argument(
         "--report",
         type=str,
         default="plain",

--- a/tests/conf/test_logging.py
+++ b/tests/conf/test_logging.py
@@ -11,12 +11,13 @@ def test_setup_logger_level():
         ("NOTEXISTS", logging.INFO),
         ("BASIC_FORMAT", logging.INFO),
     ]
+    logFile = None
     for level, expected in test_cases:
-        setup_logger(level)
+        setup_logger(level, logFile)
         actual = logging.getLogger().getEffectiveLevel()
         assert actual == expected, f"{level} level should be {expected} (got {actual})"
 
 
 def test_setup_logger_none():
-    setup_logger("NONE")
+    setup_logger("NONE", None)
     assert logging.getLogger().manager.disable == logging.CRITICAL


### PR DESCRIPTION
## Description
Fixes #329 
Added `--log-file` option to redirect log output to a user specified file.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/master/CONTRIBUTING.md).

## Fixed Issues

Please mention any issues fixed in the PR by referencing it properly in the commit message.
As per the convention, use appropriate keywords such as `fixes`, `closes`, `resolves` to automatically refer the issue.
Please consult [official github documentation](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) for details.

Fixes #(329)

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

### BEFORE
No way to redirect log output to any file.

### AFTER
![hunterlog1](https://user-images.githubusercontent.com/21288765/95776058-3584c280-0ce1-11eb-8783-357d1c5f62eb.PNG)


## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [x] I have added automated testing to cover this case.
 
## Notes
Have modified the existing test case for logging. Not completely sure whether that is enough.
