### PR TITLE
Change KB links to avd

### DIFF
--- a/kube_hunter/modules/report/base.py
+++ b/kube_hunter/modules/report/base.py
@@ -34,12 +34,13 @@ class BaseReporter:
             return [
                 {
                     "location": vuln.location(),
-                    "vid": FULL_KB_LINK.format(vid=vuln.get_vid().lower()),
+                    "vid": vuln.get_vid(),
                     "category": vuln.category.name,
                     "severity": vuln.get_severity(),
                     "vulnerability": vuln.get_name(),
                     "description": vuln.explain(),
                     "evidence": str(vuln.evidence),
+                    "avd_reference": FULL_KB_LINK.format(vid=vuln.get_vid().lower()),
                     "hunter": vuln.hunter.get_name(),
                 }
                 for vuln in vulnerabilities

--- a/kube_hunter/modules/report/base.py
+++ b/kube_hunter/modules/report/base.py
@@ -63,6 +63,6 @@ class BaseReporter:
         if statistics:
             report["hunter_statistics"] = self.get_hunter_statistics()
 
-        report["kburl"] = "https://aquasecurity.github.io/kube-hunter/kb/{vid}"
+        report["kburl"] = "https://avd.aquasec.com/kube-hunter/{vid}"
 
         return report

--- a/kube_hunter/modules/report/base.py
+++ b/kube_hunter/modules/report/base.py
@@ -7,6 +7,8 @@ from kube_hunter.modules.report.collector import (
     vulnerabilities_lock,
 )
 
+BASE_KB_LINK = "https://avd.aquasec.com/"
+FULL_KB_LINK = "https://avd.aquasec.com/kube-hunter/{vid}/"
 
 class BaseReporter:
     def get_nodes(self):
@@ -32,7 +34,7 @@ class BaseReporter:
             return [
                 {
                     "location": vuln.location(),
-                    "vid": vuln.get_vid(),
+                    "vid": FULL_KB_LINK.format(vid=vuln.get_vid().lower()),
                     "category": vuln.category.name,
                     "severity": vuln.get_severity(),
                     "vulnerability": vuln.get_name(),
@@ -62,7 +64,5 @@ class BaseReporter:
 
         if statistics:
             report["hunter_statistics"] = self.get_hunter_statistics()
-
-        report["kburl"] = "https://avd.aquasec.com/kube-hunter/{vid}"
 
         return report

--- a/kube_hunter/modules/report/base.py
+++ b/kube_hunter/modules/report/base.py
@@ -10,6 +10,7 @@ from kube_hunter.modules.report.collector import (
 BASE_KB_LINK = "https://avd.aquasec.com/"
 FULL_KB_LINK = "https://avd.aquasec.com/kube-hunter/{vid}/"
 
+
 class BaseReporter:
     def get_nodes(self):
         nodes = list()

--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -1,6 +1,6 @@
 from prettytable import ALL, PrettyTable
 
-from kube_hunter.modules.report.base import BaseReporter
+from kube_hunter.modules.report.base import BaseReporter, BASE_KB_LINK
 from kube_hunter.modules.report.collector import (
     services,
     vulnerabilities,
@@ -11,7 +11,6 @@ from kube_hunter.modules.report.collector import (
 
 EVIDENCE_PREVIEW = 100
 MAX_TABLE_WIDTH = 20
-KB_LINK = "https://github.com/aquasecurity/kube-hunter/tree/master/docs/_kb"
 
 
 class PlainReporter(BaseReporter):
@@ -114,7 +113,7 @@ class PlainReporter(BaseReporter):
         return (
             "\nVulnerabilities\n"
             "For further information about a vulnerability, search its ID in: \n"
-            f"{KB_LINK}\n{vuln_table}\n"
+            f"{BASE_KB_LINK}\n{vuln_table}\n"
         )
 
     def hunters_table(self):


### PR DESCRIPTION
## Description
Updated KB links to link to avd.aquasec.com

In general table reporting, this will be seen as:
```bash
...
Vulnerabilities
For further information about a vulnerability, search its ID in:
https://avd.aquasec.com/
+--------+---------------------+----------------------+----------------------+----------------------+------------+
...
```

And in json reporting, we build the full avd url and adding it to the resulting vulnerability object. as a new `avd_reference` var
```json
{
  "location":"127.0.0.1:10250",
  "vid":"KHV040",
  "category":"Remote Code Execution",
  "severity":"high",
  "vulnerability":"Exposed Run Inside Container",
  "description":"An attacker could run an arbitrary command inside a container",
  "evidence":"",
  "avd_reference":"https://avd.aquasec.com/kube-hunter/khv040/",
  "hunter":"Kubelet Secure Ports Hunter"
}
```

## Fixed Issues

closes #405

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 