### PR TITLE
Added docs for exposed pods

### DIFF
--- a/docs/_kb/KHV052.md
+++ b/docs/_kb/KHV052.md
@@ -1,0 +1,23 @@
+---
+vid: KHV052
+title: Exposed Pods
+categories: [Information Disclosure]
+---
+
+# {{ page.vid }} - {{ page.title }}
+
+## Issue description
+
+An attacker could view sensitive information about pods that are bound to a Node using the exposed /pods endpoint
+This can be done either by accessing the readonly port (default 10255), or from the secure kubelet port (10250)
+
+## Remediation
+
+Ensure kubelet is protected using `--anonymous-auth=false` kubelet flag. Allow only legitimate users using `--client-ca-file` or `--authentication-token-webhook` kubelet flags. This is usually done by the installer or cloud provider.
+
+Disable the readonly port by using `--read-only-port=0` kubelet flag.
+
+## References
+
+- [Kubelet configuration](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
+- [Kubelet authentication/authorization](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/)

--- a/kube_hunter/modules/hunting/kubelet.py
+++ b/kube_hunter/modules/hunting/kubelet.py
@@ -35,11 +35,7 @@ class ExposedPodsHandler(Vulnerability, Event):
 
     def __init__(self, pods):
         Vulnerability.__init__(
-            self,
-            component=Kubelet,
-            name="Exposed Pods",
-            category=InformationDisclosure,
-            vid="KHV052"
+            self, component=Kubelet, name="Exposed Pods", category=InformationDisclosure, vid="KHV052"
         )
         self.pods = pods
         self.evidence = f"count: {len(self.pods)}"

--- a/kube_hunter/modules/hunting/kubelet.py
+++ b/kube_hunter/modules/hunting/kubelet.py
@@ -39,6 +39,7 @@ class ExposedPodsHandler(Vulnerability, Event):
             component=Kubelet,
             name="Exposed Pods",
             category=InformationDisclosure,
+            vid="KHV052"
         )
         self.pods = pods
         self.evidence = f"count: {len(self.pods)}"


### PR DESCRIPTION
## Description
Exposed pods was lacking a vid and a corresponding khv page.
From now on its `KHV052`

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 