### PR TITLE
Bug Fix: Pyinstaller prettytable error

### DIFF
--- a/pyinstaller_hooks/hook-prettytable.py
+++ b/pyinstaller_hooks/hook-prettytable.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_all
+
+datas, binaries, hiddenimports = collect_all('prettytable')

--- a/pyinstaller_hooks/hook-prettytable.py
+++ b/pyinstaller_hooks/hook-prettytable.py
@@ -1,3 +1,3 @@
 from PyInstaller.utils.hooks import collect_all
 
-datas, binaries, hiddenimports = collect_all('prettytable')
+datas, binaries, hiddenimports = collect_all("prettytable")

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ class PyInstallerCommand(Command):
         cfg.read("setup.cfg")
         command = [
             "pyinstaller",
+            "--additional-hooks-dir",
+            "pyinstaller_hooks"
             "--clean",
             "--onefile",
             "--name",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ class PyInstallerCommand(Command):
         command = [
             "pyinstaller",
             "--additional-hooks-dir",
-            "pyinstaller_hooks"
+            "pyinstaller_hooks",
             "--clean",
             "--onefile",
             "--name",


### PR DESCRIPTION
## Description
As described in issue #418 pyinstaller failed to correctly import prettytable
Because this turns out to happen a lot lately, In addition to a fix to the `prettytable` import, this PR adds `pyinstaller_hooks` folder, Which in the future will contain other specific problematic packages import fixes.

## Fixed Issues
fixes #418 

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 