### PR TITLE
Updated kramdown to a patched version

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       jekyll-theme-time-machine (= 0.1.1)
       jekyll-titles-from-headings (= 0.5.1)
       jemoji (= 0.10.2)
-      kramdown (= 1.17.0)
+      kramdown (>= 2.3.0)
       liquid (= 4.0.0)
       listen (= 3.1.5)
       mercenary (~> 0.3)


### PR DESCRIPTION
## Description
Updated kramdown to a newer patched version, the old version was not patched to CVE-2020-14001

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 