### PR TITLE
Document --quick option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ To specify interface scanning, you can use the `--interface` option (this will s
 To specify a specific CIDR to scan, use the `--cidr` option. Example:
 `kube-hunter --cidr 192.168.0.0/24`
 
+4. **Quick scanning**
+
+To limit subnet scanning to a `/24` CIDR, use the `--quick` option. This option only applies when running as a Pod in Azure.
+
 ### Active Hunting
 
 Active hunting is an option in which kube-hunter will exploit vulnerabilities it finds, to explore for further vulnerabilities.


### PR DESCRIPTION
## Description
This change adds a bit of documentation concerning the `--quick` option. I did not create an issue beforehand as I believe that this is a "trivial documentation" change (as described in `CONTRIBUTING.md`).  This change was inspired by discussion on https://github.com/aquasecurity/starboard/issues/165.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/main/CONTRIBUTING.md).

## Fixed Issues

N/A

## "BEFORE" and "AFTER" output

N/A

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository. (N/A)
 - [x] I have added automated testing to cover this case. (N/A)
 
## Notes

N/A