### PR TITLE
Add discovery hunter for AWS metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Available dispatch methods are:
 
 ### Advanced Usage 
 #### Azure Quick Scanning 
-When running **as a Pod in an Azure environment**, kube-hunter will fetch subnets from the Instance Metadata Service. Naturally this makes the discovery process take longer.
+When running **as a Pod in an Azure or AWS environment**, kube-hunter will fetch subnets from the Instance Metadata Service. Naturally this makes the discovery process take longer.
 To hardlimit subnet scanning to a `/24` CIDR, use the `--quick` option. 
 
 ## Deployment

--- a/docs/_kb/KHV053.md
+++ b/docs/_kb/KHV053.md
@@ -1,0 +1,24 @@
+---
+vid: KHV053
+title: AWS Metadata Exposure
+categories: [Information Disclosure]
+---
+
+# {{ page.vid }} - {{ page.title }}
+
+## Issue description
+
+AWS EC2 provides an internal HTTP endpoint that exposes information from the cloud platform to workloads running in an instance. The endpoint is accessible to every workload running in the instance. An attacker that is able to execute a pod in the cluster may be able to query the metadata service and discover additional information about the environment.
+
+## Remediation
+
+* Limit access to the instance metadata service. Consider using a local firewall such as `iptables` to disable access from some or all processes/users to the instance metadata service.
+
+* Disable the metadata service (via instance metadata options or IAM), or at a minimum enforce the use IMDSv2 on an instance to require token-based access to the service.
+
+* Modify the HTTP PUT response hop limit on the instance to 1. This will only allow access to the service from the instance itself rather than from within a pod.
+
+## References
+
+- [AWS Instance Metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html)
+- [EC2 Instance Profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)

--- a/kube_hunter/core/types.py
+++ b/kube_hunter/core/types.py
@@ -50,6 +50,12 @@ class Kubelet(KubernetesCluster):
     name = "Kubelet"
 
 
+class AWS(KubernetesCluster):
+    """AWS Cluster"""
+
+    name = "AWS"
+
+
 class Azure(KubernetesCluster):
     """Azure Cluster"""
 

--- a/tests/discovery/test_hosts.py
+++ b/tests/discovery/test_hosts.py
@@ -1,4 +1,12 @@
 # flake8: noqa: E402
+from kube_hunter.modules.discovery.hosts import (
+    FromPodHostDiscovery,
+    RunningAsPodEvent,
+    HostScanEvent,
+    HostDiscoveryHelpers,
+)
+from kube_hunter.core.types import Hunter
+from kube_hunter.core.events import handler
 import json
 import requests_mock
 import pytest
@@ -9,19 +17,10 @@ from kube_hunter.conf import Config, get_config, set_config
 
 set_config(Config())
 
-from kube_hunter.core.events import handler
-from kube_hunter.core.types import Hunter
-from kube_hunter.modules.discovery.hosts import (
-    FromPodHostDiscovery,
-    RunningAsPodEvent,
-    HostScanEvent,
-    HostDiscoveryHelpers,
-)
-
 
 class TestFromPodHostDiscovery:
     @staticmethod
-    def _make_response(*subnets: List[tuple]) -> str:
+    def _make_azure_response(*subnets: List[tuple]) -> str:
         return json.dumps(
             {
                 "network": {
@@ -31,6 +30,10 @@ class TestFromPodHostDiscovery:
                 }
             }
         )
+
+    @staticmethod
+    def _make_aws_response(*data: List[str]) -> str:
+        return "\n".join(data)
 
     def test_is_azure_pod_request_fail(self):
         f = FromPodHostDiscovery(RunningAsPodEvent())
@@ -47,9 +50,122 @@ class TestFromPodHostDiscovery:
         with requests_mock.Mocker() as m:
             m.get(
                 "http://169.254.169.254/metadata/instance?api-version=2017-08-01",
-                text=TestFromPodHostDiscovery._make_response(("3.4.5.6", "255.255.255.252")),
+                text=TestFromPodHostDiscovery._make_azure_response(("3.4.5.6", "255.255.255.252")),
             )
             result = f.is_azure_pod()
+
+        assert result
+
+    def test_is_aws_pod_v1_request_fail(self):
+        f = FromPodHostDiscovery(RunningAsPodEvent())
+
+        with requests_mock.Mocker() as m:
+            m.get("http://169.254.169.254/latest/meta-data/", status_code=404)
+            result = f.is_aws_pod_v1()
+
+        assert not result
+
+    def test_is_aws_pod_v1_success(self):
+        f = FromPodHostDiscovery(RunningAsPodEvent())
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://169.254.169.254/latest/meta-data/",
+                text=TestFromPodHostDiscovery._make_aws_response(
+                    "\n".join(
+                        (
+                            "ami-id",
+                            "ami-launch-index",
+                            "ami-manifest-path",
+                            "block-device-mapping/",
+                            "events/",
+                            "hostname",
+                            "iam/",
+                            "instance-action",
+                            "instance-id",
+                            "instance-type",
+                            "local-hostname",
+                            "local-ipv4",
+                            "mac",
+                            "metrics/",
+                            "network/",
+                            "placement/",
+                            "profile",
+                            "public-hostname",
+                            "public-ipv4",
+                            "public-keys/",
+                            "reservation-id",
+                            "security-groups",
+                            "services/",
+                        )
+                    ),
+                ),
+            )
+            result = f.is_aws_pod_v1()
+
+        assert result
+
+    def test_is_aws_pod_v2_request_fail(self):
+        f = FromPodHostDiscovery(RunningAsPodEvent())
+
+        with requests_mock.Mocker() as m:
+            m.put(
+                "http://169.254.169.254/latest/api/token/",
+                headers={"X-aws-ec2-metatadata-token-ttl-seconds": "21600"},
+                status_code=404,
+            )
+            m.get(
+                "http://169.254.169.254/latest/meta-data/",
+                headers={"X-aws-ec2-metatadata-token": "token"},
+                status_code=404,
+            )
+            result = f.is_aws_pod_v2()
+
+        assert not result
+
+    def test_is_aws_pod_v2_success(self):
+        f = FromPodHostDiscovery(RunningAsPodEvent())
+
+        with requests_mock.Mocker() as m:
+            m.put(
+                "http://169.254.169.254/latest/api/token/",
+                headers={"X-aws-ec2-metatadata-token-ttl-seconds": "21600"},
+                text=TestFromPodHostDiscovery._make_aws_response("token"),
+            )
+            m.get(
+                "http://169.254.169.254/latest/meta-data/",
+                headers={"X-aws-ec2-metatadata-token": "token"},
+                text=TestFromPodHostDiscovery._make_aws_response(
+                    "\n".join(
+                        (
+                            "ami-id",
+                            "ami-launch-index",
+                            "ami-manifest-path",
+                            "block-device-mapping/",
+                            "events/",
+                            "hostname",
+                            "iam/",
+                            "instance-action",
+                            "instance-id",
+                            "instance-type",
+                            "local-hostname",
+                            "local-ipv4",
+                            "mac",
+                            "metrics/",
+                            "network/",
+                            "placement/",
+                            "profile",
+                            "public-hostname",
+                            "public-ipv4",
+                            "public-keys/",
+                            "reservation-id",
+                            "security-groups",
+                            "services/",
+                        )
+                    ),
+                ),
+            )
+            result = f.is_aws_pod_v2()
 
         assert result
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Adds a discovery hunter to identify access to the AWS metadata service.  Has checks for both version 1 and 2 (session based) of the service.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/main/CONTRIBUTING.md).

## Fixed Issues

Partially fixes #45 by providing a hunter that identifies access to the AWS instance metadata service versions 1 & 2.


## "BEFORE" and "AFTER" output

### BEFORE
```
$ kubectl apply -f job.yaml
$ kubectl logs job/kube-hunter | grep -v INFO | jq -r '.vulnerabilities | .[] | .vulnerability,.vid'
Read access to pod's service account token
KHV050
Access to pod's secrets
None
CAP_NET_RAW Enabled
None
Access to API using service account token
KHV005
K8s Version Disclosure
KHV002
```

### AFTER
```
$ kubectl apply -f job.yaml
$ kubectl logs job/kube-hunter | grep -v INFO | jq -r '.vulnerabilities | .[] | select(.vid=="KHV053")'
{
  "location": "Local to Pod (kube-hunter-9qfnr)",
  "vid": "KHV053",
  "category": "Information Disclosure",
  "severity": "medium",
  "vulnerability": "AWS Metadata Exposure",
  "description": "Access to the AWS Metadata API exposes information about the machines associated with the cluster",
  "evidence": "cidr: 192.168.0.0/19",
  "avd_reference": "https://avd.aquasec.com/kube-hunter/khv053/",
  "hunter": "Host Discovery when running as pod"
}
```

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [x] I have added automated testing to cover this case.
 