### PR TITLE
Multiple Subscriptions Mechanism

### DIFF
--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -179,8 +179,8 @@ class EventQueue(Queue):
                             events_container = MultipleEventsContainer(self._get_latest_events_from_multi_hooks(hook))
                             self.put(hook(events_container))
                             logger.debug(
-                                f"Multiple subscription requirements were met for hunter {hook}. events container was published with \
-                                {self.hook_fulfilled_deps[hook].keys()}"
+                                f"Multiple subscription requirements were met for hunter {hook}. events container was \
+                                published with {self.hook_fulfilled_deps[hook].keys()}"
                             )
 
     """

--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -36,7 +36,8 @@ class EventQueue(Queue):
         # Structure: key: Hunter Class, value: set(RequiredEventClass1, RequiredEventClass2)
         self.hook_dependencies = defaultdict(set)
 
-        # To keep track of fulfilled dependencies. we need to have a structure which saves historical instanciated events mapped to a registered hunter.
+        # To keep track of fulfilled dependencies. we need to have a structure which saves historical instanciated
+        # events mapped to a registered hunter.
         # We used a 2 dimensional dictionary in order to fulfill two demands:
         #   * correctly count published required events
         #   * save historical events fired, easily sorted by their type
@@ -178,7 +179,8 @@ class EventQueue(Queue):
                             events_container = MultipleEventsContainer(self._get_latest_events_from_multi_hooks(hook))
                             self.put(hook(events_container))
                             logger.debug(
-                                f"Multiple subscription requirements were met for hunter {hook}. events container was published with {self.hook_fulfilled_deps[hook].keys()}"
+                                f"Multiple subscription requirements were met for hunter {hook}. events container was published with \
+                                {self.hook_fulfilled_deps[hook].keys()}"
                             )
 
     """

--- a/kube_hunter/core/events/types.py
+++ b/kube_hunter/core/events/types.py
@@ -62,6 +62,20 @@ class Event:
         return history
 
 
+class MultipleEventsContainer(Event):
+    """
+    This is the class of the object an hunter will get if he was registered to multiple events.
+    """
+
+    def __init__(self, events):
+        self.events = events
+
+    def get_by_class(self, event_class):
+        for event in self.events:
+            if event.__class__ == event_class:
+                return event
+
+
 class Service:
     def __init__(self, name, path="", secure=True):
         self.name = name

--- a/tests/core/test_subscribe.py
+++ b/tests/core/test_subscribe.py
@@ -6,6 +6,8 @@ from kube_hunter.core.events.types import Event, Service
 from kube_hunter.core.events import handler
 
 counter = 0
+first_run = True
+
 set_config(Config())
 
 
@@ -13,17 +15,21 @@ class OnceOnlyEvent(Service, Event):
     def __init__(self):
         Service.__init__(self, "Test Once Service")
 
+
 class RegularEvent(Service, Event):
     def __init__(self):
         Service.__init__(self, "Test Service")
+
 
 class AnotherRegularEvent(Service, Event):
     def __init__(self):
         Service.__init__(self, "Test Service (another)")
 
+
 class DifferentRegularEvent(Service, Event):
     def __init__(self):
         Service.__init__(self, "Test Service (different)")
+
 
 @handler.subscribe_once(OnceOnlyEvent)
 class OnceHunter(Hunter):
@@ -38,16 +44,38 @@ class RegularHunter(Hunter):
         global counter
         counter += 1
 
+
 @handler.subscribe_many([DifferentRegularEvent, AnotherRegularEvent])
 class SmartHunter(Hunter):
+    def __init__(self, events):
+        global counter, first_run
+        counter += 1
+
+        # we add an attribute on the second scan.
+        # here we test that we get the latest event
+        different_event = events.get_by_class(DifferentRegularEvent)
+        if first_run:
+            first_run = False
+            assert different_event.new_value == None
+        else:
+            assert different_event.new_value
+
+
+@handler.subscribe_many([DifferentRegularEvent, AnotherRegularEvent])
+class SmartHunter2(Hunter):
     def __init__(self, events):
         global counter
         counter += 1
 
+        # check if we can access the events
+        assert events.get_by_class(DifferentRegularEvent).__class__ == DifferentRegularEvent
+        assert events.get_by_class(AnotherRegularEvent).__class__ == AnotherRegularEvent
+
+
 def test_subscribe_mechanism():
     global counter
     counter = 0
-    
+
     # first test normal subscribe and publish works
     handler.publish_event(RegularEvent())
     handler.publish_event(RegularEvent())
@@ -55,6 +83,7 @@ def test_subscribe_mechanism():
 
     time.sleep(0.02)
     assert counter == 3
+
 
 def test_subscribe_once_mechanism():
     global counter
@@ -81,23 +110,20 @@ def test_subscribe_many_mechanism():
 
     # testing the multiple subscription mechanism
     handler.publish_event(DifferentRegularEvent())
-    handler.publish_event(AnotherRegularEvent())
     handler.publish_event(DifferentRegularEvent())
+    handler.publish_event(DifferentRegularEvent())
+    handler.publish_event(DifferentRegularEvent())
+    handler.publish_event(DifferentRegularEvent())
+    handler.publish_event(AnotherRegularEvent())
 
     time.sleep(0.02)
-    # We expect that SmartHunter to run once and RegularEvent to run once.
+    # We expect SmartHunter and SmartHunter2 to be executed once. hence the counter should be 2
     assert counter == 2
     counter = 0
 
-    handler.publish_event(AnotherRegularEvent())
-    handler.publish_event(AnotherRegularEvent())
-    handler.publish_event(AnotherRegularEvent())
-    handler.publish_event(DifferentRegularEvent())
-    handler.publish_event(DifferentRegularEvent())
-    handler.publish_event(DifferentRegularEvent())
+    # Test using most recent event
+    newer_version_event = DifferentRegularEvent()
+    newer_version_event.new_value = True
+    handler.publish_event(newer_version_event)
 
-    time.sleep(0.02)
-    # (Regular, Another) or (Another, Regular) sequences trigger the SmartHunter.
-    # Regular trigger the RegularHunter.
-    # OnceHunter should not be triggered here.
-    assert counter == 1
+    assert counter == 2

--- a/tests/core/test_subscribe.py
+++ b/tests/core/test_subscribe.py
@@ -56,7 +56,7 @@ class SmartHunter(Hunter):
         different_event = events.get_by_class(DifferentRegularEvent)
         if first_run:
             first_run = False
-            assert different_event.new_value == None
+            assert not different_event.new_value
         else:
             assert different_event.new_value
 


### PR DESCRIPTION
# Multiple Subscriptions
A continuation for this old PR #271 
When an hunter needs several prerequisites to exist in the cluster, We need to register for multiple events.
This new mechanism allows us to execute once for every new combination of specified required events.
For example:
let a C hunter be registered to event A and B

1. event A was published 3 times 
2. event B was published once.
3. event B was published again
 
The hunter will execute 2 times:
* (on step 2) with the newest version of A
* (on step 3) with the newest version of A and newest version of B

This allows us to run specific hunters multiple times with updated data, only when a minimum set of different events are published. 

## Practical Changes
This PR Adds:
* A new decorator - `@handler.subscribe_many()`
  * Gets a list of events - `[Event1, Event2]`
* A new type of event, `MultipleEventsContainer` which is passed to a hunter which subscribes using `subscribe_many`
  * implements `get_by_class` method, to get specific events from the container.
* Unit Tests
* Documentation to this and other backend logic

Example can be seen in added Tests

## Fixed Issues
#144 

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [x] I have added automated testing to cover this case.
 