### PR TITLE
fix(job): working with PodSecurityPolicies

### DIFF
--- a/job.yaml
+++ b/job.yaml
@@ -12,4 +12,6 @@ spec:
           command: ["kube-hunter"]
           args: ["--pod"]
       restartPolicy: Never
+      securityContext:
+        runAsUser: 1000
   backoffLimit: 4


### PR DESCRIPTION

## Description

Fixes the Kubernetes job sample.

## Fixed Issues

Without this patch, starting a scan using the job.yaml provided here would result in Pod refusing to start - when Kubernetes PodSecurityPolicy are enabled

## "BEFORE" and "AFTER" output

### BEFORE

```
$ kubectl get pods
kube-hunter-bn6r5   0/1     CreateContainerConfigError   0          3m8s
$ kubectl describe pod kube-hunter-bn6r5
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
  Normal   Scheduled  12s               default-scheduler  Successfully assigned default/kube-hunter-nosec-bn6r5 to compute1
  Normal   Pulled     1s                kubelet            Successfully pulled image "aquasec/kube-hunter" in 10.090423719s
  Warning  Failed     1s                kubelet            Error: container has runAsNonRoot and image will run as root
  Normal   Pulling    0s (x2 over 11s)  kubelet            Pulling image "aquasec/kube-hunter"
```

### AFTER

```
$ kubectl get pods
kube-hunter-cfzrt         0/1     Completed                    0          9h
```

## Contribution checklist

 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes

No changes to python code, I did not open an issue, nor did I find another one that would mention this. I did not add checks, have not written tests, ...
Being a small / obvious patch, Kubernetes-specific, I hope this would not be an issue. Otherwise let me know.