### PR TITLE
Fixed exception logs in kubernetes_client

### DIFF
--- a/kube_hunter/modules/discovery/kubernetes_client.py
+++ b/kube_hunter/modules/discovery/kubernetes_client.py
@@ -6,13 +6,13 @@ def list_all_k8s_cluster_nodes(kube_config=None, client=None):
     logger = logging.getLogger(__name__)
     try:
         if kube_config:
-            logger.info("Attempting to use kubeconfig file: %s", kube_config)
+            logger.debug("Attempting to use kubeconfig file: %s", kube_config)
             kubernetes.config.load_kube_config(config_file=kube_config)
         else:
-            logger.info("Attempting to use in cluster Kubernetes config")
+            logger.debug("Attempting to use in cluster Kubernetes config")
             kubernetes.config.load_incluster_config()
     except kubernetes.config.config_exception.ConfigException as ex:
-        logger.exception(f"Failed to initiate Kubernetes client: {ex}")
+        logger.debug(f"Failed to initiate Kubernetes client: {ex}")
         return
 
     try:
@@ -24,4 +24,4 @@ def list_all_k8s_cluster_nodes(kube_config=None, client=None):
             for addr in item.status.addresses:
                 yield addr.address
     except Exception as ex:
-        logger.exception(f"Failed to list nodes from Kubernetes: {ex}")
+        logger.debug(f"Failed to list nodes from Kubernetes: {ex}")


### PR DESCRIPTION
Changed exception logs to debug logs in kubernetes_client nodes discovery

Permissions to list nodes is usually not granted to the default service account. This resulted in unnecessary exception logs.
Changed to debug logging. 