### PR TITLE
modify error when cluster resources  unreachable

### DIFF
--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -137,10 +137,8 @@ class EventQueue(Queue):
         # Document that the hunter published a vulnerability (if it's indeed a vulnerability)
         # For statistics options
         self._increase_vuln_count(event, caller)
-
         # sets the event's parent to be it's publisher hunter.
         self._set_event_chain(event, caller)
-
         # applying filters on the event, before publishing it to subscribers.
         # if filter returned None, not proceeding to publish
         event = self.apply_filters(event)
@@ -224,8 +222,6 @@ class EventQueue(Queue):
         if caller:
             event.previous = caller.event
             event.hunter = caller.__class__
-            if "error" in caller.__dict__:
-                event.error = caller.error
 
     def _register_hunters(self, hook=None):
         """

--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -224,6 +224,8 @@ class EventQueue(Queue):
         if caller:
             event.previous = caller.event
             event.hunter = caller.__class__
+            if "error" in caller.__dict__:
+                event.error = caller.error
 
     def _register_hunters(self, hook=None):
         """

--- a/kube_hunter/core/events/types.py
+++ b/kube_hunter/core/events/types.py
@@ -32,6 +32,7 @@ class Event:
     def __init__(self):
         self.previous = None
         self.hunter = None
+        self.error = None
 
     # newest attribute gets selected first
     def __getattr__(self, name):

--- a/kube_hunter/core/events/types.py
+++ b/kube_hunter/core/events/types.py
@@ -190,11 +190,15 @@ class NewHostEvent(Event):
 
 
 class OpenPortEvent(Event):
-    def __init__(self, port):
+    def __init__(self, port=None,error="default"):
         self.port = port
+        self.error = error
 
     def __str__(self):
         return str(self.port)
+    
+    def __repr__(self):
+        return str(self.error)
 
     # Event's logical location to be used mainly for reports.
     def location(self):

--- a/kube_hunter/core/events/types.py
+++ b/kube_hunter/core/events/types.py
@@ -32,7 +32,7 @@ class Event:
     def __init__(self):
         self.previous = None
         self.hunter = None
-        self.error = None
+        #self.error = None
 
     # newest attribute gets selected first
     def __getattr__(self, name):
@@ -138,6 +138,12 @@ class Vulnerability:
     def get_severity(self):
         return self.severity.get(self.category, "low")
 
+class HuntError(Event):
+    def __init__(self,error):
+        self.error = error
+
+    def __str__(self):
+        return str(self.error)
 
 event_id_count_lock = threading.Lock()
 event_id_count = 0

--- a/kube_hunter/core/events/types.py
+++ b/kube_hunter/core/events/types.py
@@ -32,7 +32,6 @@ class Event:
     def __init__(self):
         self.previous = None
         self.hunter = None
-        #self.error = None
 
     # newest attribute gets selected first
     def __getattr__(self, name):

--- a/kube_hunter/core/events/types.py
+++ b/kube_hunter/core/events/types.py
@@ -138,6 +138,7 @@ class Vulnerability:
         return self.severity.get(self.category, "low")
 
 class HuntError(Event):
+    
     def __init__(self,error):
         self.error = error
 

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -52,9 +52,13 @@ class ApiServiceDiscovery(Discovery):
     def execute(self):
         logger.debug(f"Attempting to discover an API service on {self.event.host}:{self.event.port}")
         protocols = ["http", "https"]
+        flag = True
         for protocol in protocols:
             if self.has_api_behaviour(protocol):
+                flag = False
                 self.publish_event(K8sApiService(protocol))
+        if flag:
+            logger.debug("Failed to connect to ApiServer Service")
 
     def has_api_behaviour(self, protocol):
         config = get_config()

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -60,7 +60,7 @@ class ApiServiceDiscovery(Discovery):
                 self.publish_event(K8sApiService(protocol))
         if flag:
             logger.debug("Failed to connect to ApiServer Service")
-            self.publish_event(HuntError("Failed to connect to ApiServer Service"))
+            self.publish_event(OpenPortEvent(error="Failed to connect to ApiServer Service at port 8080"))
 
     def has_api_behaviour(self, protocol):
         config = get_config()

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -3,7 +3,7 @@ import requests
 
 from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
-from kube_hunter.core.events.types import OpenPortEvent, Service, Event, EventFilterBase
+from kube_hunter.core.events.types import HuntFinished, HuntError,OpenPortEvent, Service, Event, EventFilterBase
 
 from kube_hunter.conf import get_config
 
@@ -60,7 +60,7 @@ class ApiServiceDiscovery(Discovery):
                 self.publish_event(K8sApiService(protocol))
         if flag:
             logger.debug("Failed to connect to ApiServer Service")
-            self.error = "Failed to connect to ApiServer Service"
+            self.publish_event(HuntError("Failed to connect to ApiServer Service"))
 
     def has_api_behaviour(self, protocol):
         config = get_config()

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -3,7 +3,7 @@ import requests
 
 from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
-from kube_hunter.core.events.types import HuntFinished, HuntError,OpenPortEvent, Service, Event, EventFilterBase
+from kube_hunter.core.events.types import HuntFinished, HuntError, OpenPortEvent, Service, Event, EventFilterBase
 
 from kube_hunter.conf import get_config
 

--- a/kube_hunter/modules/discovery/apiserver.py
+++ b/kube_hunter/modules/discovery/apiserver.py
@@ -48,6 +48,7 @@ class ApiServiceDiscovery(Discovery):
         self.event = event
         self.session = requests.Session()
         self.session.verify = False
+        self.error = ""
 
     def execute(self):
         logger.debug(f"Attempting to discover an API service on {self.event.host}:{self.event.port}")
@@ -59,6 +60,7 @@ class ApiServiceDiscovery(Discovery):
                 self.publish_event(K8sApiService(protocol))
         if flag:
             logger.debug("Failed to connect to ApiServer Service")
+            self.error = "Failed to connect to ApiServer Service"
 
     def has_api_behaviour(self, protocol):
         config = get_config()

--- a/kube_hunter/modules/discovery/kubectl.py
+++ b/kube_hunter/modules/discovery/kubectl.py
@@ -3,7 +3,7 @@ import subprocess
 
 from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
-from kube_hunter.core.events.types import HuntStarted, Event
+from kube_hunter.core.events.types import HuntStarted, Event, OpenPortEvent
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,7 @@ class KubectlClientDiscovery(Discovery):
                 start = version_info.find("GitVersion")
                 version = version_info[start + len("GitVersion':\"") : version_info.find('",', start)]
         except Exception:
+            self.publish_event(OpenPortEvent(error="Could not find kubectl client"))
             logger.debug("Could not find kubectl client")
         return version
 

--- a/kube_hunter/modules/discovery/ports.py
+++ b/kube_hunter/modules/discovery/ports.py
@@ -3,7 +3,7 @@ from socket import socket
 
 from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
-from kube_hunter.core.events.types import HuntFinished, NewHostEvent, OpenPortEvent
+from kube_hunter.core.events.types import HuntFinished, NewHostEvent, OpenPortEvent,HuntError
 
 logger = logging.getLogger(__name__)
 default_ports = [8001, 8080, 10250, 10255, 30000, 443, 6443, 2379]
@@ -31,8 +31,8 @@ class PortDiscovery(Discovery):
                 self.publish_event(OpenPortEvent(port=single_port))
         if flag:
             logger.debug("Failed to find any Open Ports")
-            self.error = "Failed to find any Open Ports"
-            self.publish_event(HuntFinished())
+            self.publish_event(HuntError("Failed to find any Open Ports"))
+            
 
     @staticmethod
     def test_connection(host, port):

--- a/kube_hunter/modules/discovery/ports.py
+++ b/kube_hunter/modules/discovery/ports.py
@@ -3,7 +3,7 @@ from socket import socket
 
 from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
-from kube_hunter.core.events.types import NewHostEvent, OpenPortEvent
+from kube_hunter.core.events.types import HuntFinished, NewHostEvent, OpenPortEvent
 
 logger = logging.getLogger(__name__)
 default_ports = [8001, 8080, 10250, 10255, 30000, 443, 6443, 2379]
@@ -19,6 +19,7 @@ class PortDiscovery(Discovery):
         self.event = event
         self.host = event.host
         self.port = event.port
+        self.error = ""
 
     def execute(self):
         flag = True
@@ -30,6 +31,8 @@ class PortDiscovery(Discovery):
                 self.publish_event(OpenPortEvent(port=single_port))
         if flag:
             logger.debug("Failed to find any Open Ports")
+            self.error = "Failed to find any Open Ports"
+            self.publish_event(HuntFinished())
 
     @staticmethod
     def test_connection(host, port):

--- a/kube_hunter/modules/discovery/ports.py
+++ b/kube_hunter/modules/discovery/ports.py
@@ -31,7 +31,7 @@ class PortDiscovery(Discovery):
                 self.publish_event(OpenPortEvent(port=single_port))
         if flag:
             logger.debug("Failed to find any Open Ports")
-            self.publish_event(HuntError("Failed to find any Open Ports"))
+            self.publish_event(OpenPortEvent(error="Failed to find any Open Ports"))
             
 
     @staticmethod

--- a/kube_hunter/modules/discovery/ports.py
+++ b/kube_hunter/modules/discovery/ports.py
@@ -21,11 +21,15 @@ class PortDiscovery(Discovery):
         self.port = event.port
 
     def execute(self):
+        flag = True
         logger.debug(f"host {self.host} try ports: {default_ports}")
         for single_port in default_ports:
             if self.test_connection(self.host, single_port):
+                flag = False
                 logger.debug(f"Reachable port found: {single_port}")
                 self.publish_event(OpenPortEvent(port=single_port))
+        if flag:
+            logger.debug("Failed to find any Open Ports")
 
     @staticmethod
     def test_connection(host, port):

--- a/kube_hunter/modules/discovery/ports.py
+++ b/kube_hunter/modules/discovery/ports.py
@@ -3,7 +3,7 @@ from socket import socket
 
 from kube_hunter.core.types import Discovery
 from kube_hunter.core.events import handler
-from kube_hunter.core.events.types import HuntFinished, NewHostEvent, OpenPortEvent,HuntError
+from kube_hunter.core.events.types import HuntFinished, NewHostEvent, OpenPortEvent, HuntError
 
 logger = logging.getLogger(__name__)
 default_ports = [8001, 8080, 10250, 10255, 30000, 443, 6443, 2379]

--- a/kube_hunter/modules/discovery/proxy.py
+++ b/kube_hunter/modules/discovery/proxy.py
@@ -37,9 +37,14 @@ class KubeProxy(Discovery):
             if r.status_code == 200 and "APIResourceList" in r.text:
                 return True
         except requests.Timeout:
+            self.publish_event(OpenPortEvent(error=f"failed to get {endpoint}"))
             logger.debug(f"failed to get {endpoint}", exc_info=True)
         return False
 
     def execute(self):
         if self.accesible:
             self.publish_event(KubeProxyEvent())
+        else:
+            self.publish_event(OpenPortEvent(error=f"failed to get Proxy Service at 8001"))
+            logger.debug("Failed to get Proxy Service at 8001")
+

--- a/kube_hunter/modules/hunting/proxy.py
+++ b/kube_hunter/modules/hunting/proxy.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
-from kube_hunter.core.events.types import Event, Vulnerability, K8sVersionDisclosure
+from kube_hunter.core.events.types import Event, Vulnerability, K8sVersionDisclosure, OpenPortEvent
 from kube_hunter.core.types import (
     ActiveHunter,
     Hunter,

--- a/kube_hunter/modules/report/collector.py
+++ b/kube_hunter/modules/report/collector.py
@@ -5,11 +5,11 @@ from kube_hunter.conf import get_config
 from kube_hunter.core.events import handler
 from kube_hunter.core.events.types import (
     Event,
+    OpenPortEvent,
     Service,
     Vulnerability,
     HuntFinished,
     HuntStarted,
-    HuntError,
     ReportDispatched,
 )
 
@@ -23,7 +23,7 @@ error_lock = threading.Lock()
 errors = list()
 hunters = handler.all_hunters
 
-@handler.subscribe(HuntError)
+@handler.subscribe(OpenPortEvent)
 @handler.subscribe(Service)
 @handler.subscribe(Vulnerability)
 class Collector:
@@ -44,10 +44,12 @@ class Collector:
             with vulnerabilities_lock:
                 vulnerabilities.append(self.event)
             logger.info(f'Found vulnerability "{self.event.get_name()}" in {self.event.location()}')
-        elif HuntError in bases:
+        elif OpenPortEvent in bases:
             with error_lock:
-                errors.append(str(self.event))
-            logger.info(f'Found error "{self.event.get_name()}" in {self.event.location()}')
+                error = repr(self.event)
+                if error!="default":
+                    errors.append(error)
+            logger.info(f'Found error OpenPortEvent in {self.event.location()}')
 
 
 class TablesPrinted(Event):

--- a/kube_hunter/modules/report/collector.py
+++ b/kube_hunter/modules/report/collector.py
@@ -53,7 +53,7 @@ class SendFullReport:
 
     def execute(self):
         config = get_config()
-        report = config.reporter.get_report(statistics=config.statistics, mapping=config.mapping)
+        report = config.reporter.get_report(statistics=config.statistics, mapping=config.mapping, error = self.event.error)
         config.dispatcher.dispatch(report)
         handler.publish_event(ReportDispatched())
         handler.publish_event(TablesPrinted())

--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -22,13 +22,9 @@ class PlainReporter(BaseReporter):
             vulnerabilities_len = len(vulnerabilities)
 
         hunters_len = len(hunters.items())
-        print("****Services****")
-        print(services)
         with services_lock:
             services_len = len(services)
 
-        print("****HunterS List*****")
-        print(hunters.items())
         if services_len:
             output += self.nodes_table()
             if not mapping:

--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -42,7 +42,7 @@ class PlainReporter(BaseReporter):
         else:
             if vulnerabilities_len:
                 output += self.vulns_table()
-            output += "\nKube Hunter couldn't find any clusters"
+            output += "\nCluster Inaccessible from Kube Hunter"
         return output
 
     def nodes_table(self):

--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -8,7 +8,7 @@ from kube_hunter.modules.report.collector import (
     hunters,
     services_lock,
     vulnerabilities_lock,
-    error_lock
+    error_lock,
 )
 
 EVIDENCE_PREVIEW = 100
@@ -25,12 +25,13 @@ class PlainReporter(BaseReporter):
         hunters_len = len(hunters.items())
         with services_lock:
             services_len = len(services)
-        
+  
         with error_lock:
-            errors_len =  len(errors)
-        
+            errors_len = len(errors)
+
         if errors_len:
-            return ','.join(errors)
+            return "","".join(errors)
+
         
         if services_len:
             output += self.nodes_table()

--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -14,9 +14,11 @@ MAX_TABLE_WIDTH = 20
 
 
 class PlainReporter(BaseReporter):
-    def get_report(self, *, statistics=None, mapping=None, **kwargs):
+    def get_report(self, *, statistics=None, mapping=None,error=None, **kwargs):
         """generates report tables"""
         output = ""
+        if error is not None:
+            return error
 
         with vulnerabilities_lock:
             vulnerabilities_len = len(vulnerabilities)
@@ -24,7 +26,7 @@ class PlainReporter(BaseReporter):
         hunters_len = len(hunters.items())
         with services_lock:
             services_len = len(services)
-
+        
         if services_len:
             output += self.nodes_table()
             if not mapping:

--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -1,3 +1,4 @@
+from logging import error
 from prettytable import ALL, PrettyTable
 
 from kube_hunter.modules.report.base import BaseReporter, BASE_KB_LINK
@@ -29,10 +30,6 @@ class PlainReporter(BaseReporter):
         with error_lock:
             errors_len = len(errors)
 
-        if errors_len:
-            return "","".join(errors)
-
-        
         if services_len:
             output += self.nodes_table()
             if not mapping:
@@ -50,6 +47,10 @@ class PlainReporter(BaseReporter):
             if vulnerabilities_len:
                 output += self.vulns_table()
             output += "\nCluster Inaccessible from Kube Hunter"
+            if len(errors):
+                output += "\n\nPossible Reasons:"
+                for index, reason in enumerate(errors):
+                    output += f"\n{index+1}-> {reason}"
         return output
 
     def nodes_table(self):

--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -4,9 +4,11 @@ from kube_hunter.modules.report.base import BaseReporter, BASE_KB_LINK
 from kube_hunter.modules.report.collector import (
     services,
     vulnerabilities,
+    errors,
     hunters,
     services_lock,
     vulnerabilities_lock,
+    error_lock
 )
 
 EVIDENCE_PREVIEW = 100
@@ -14,18 +16,21 @@ MAX_TABLE_WIDTH = 20
 
 
 class PlainReporter(BaseReporter):
-    def get_report(self, *, statistics=None, mapping=None,error=None, **kwargs):
+    def get_report(self, *, statistics=None, mapping=None, **kwargs):
         """generates report tables"""
         output = ""
-        if error is not None:
-            return error
-
         with vulnerabilities_lock:
             vulnerabilities_len = len(vulnerabilities)
 
         hunters_len = len(hunters.items())
         with services_lock:
             services_len = len(services)
+        
+        with error_lock:
+            errors_len =  len(errors)
+        
+        if errors_len:
+            return ','.join(errors)
         
         if services_len:
             output += self.nodes_table()

--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -22,10 +22,13 @@ class PlainReporter(BaseReporter):
             vulnerabilities_len = len(vulnerabilities)
 
         hunters_len = len(hunters.items())
-
+        print("****Services****")
+        print(services)
         with services_lock:
             services_len = len(services)
 
+        print("****HunterS List*****")
+        print(hunters.items())
         if services_len:
             output += self.nodes_table()
             if not mapping:


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.

Modifies the Error message when cluster resources are unreachable from kube hunter

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/main/CONTRIBUTING.md).

## Fixed Issues

Please mention any issues fixed in the PR by referencing it properly in the commit message.
As per the convention, use appropriate keywords such as `fixes`, `closes`, `resolves` to automatically refer the issue.
Please consult [official github documentation](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) for details.

Fixes #477 

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

### BEFORE
Any Terminal Output Before Changes.
Kube Hunter couldn't find any clusters

### AFTER
Any Terminal Output Before Changes.
Cluster Inaccessible from Kube Hunter

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
As tests are not required for this.
