### PR TITLE
Added correct exception handling for discovery of Metadata apis

### DIFF
--- a/kube_hunter/modules/discovery/hosts.py
+++ b/kube_hunter/modules/discovery/hosts.py
@@ -166,8 +166,8 @@ class FromPodHostDiscovery(Discovery):
                 return True
         except requests.exceptions.ConnectionError:
             logger.debug("Failed to connect AWS metadata server v1")
-        except:
-            logger.debug(f"Unknown error when trying to connect to AWS metadata v1 API")
+        except Exception:
+            logger.debug("Unknown error when trying to connect to AWS metadata v1 API")
         return False
 
     def is_aws_pod_v2(self):
@@ -191,8 +191,8 @@ class FromPodHostDiscovery(Discovery):
                 return True
         except requests.exceptions.ConnectionError:
             logger.debug("Failed to connect AWS metadata server v2")
-        except:
-            logger.debug(f"Unknown error when trying to connect to AWS metadata v2 API")
+        except Exception:
+            logger.debug("Unknown error when trying to connect to AWS metadata v2 API")
         return False
 
     def is_azure_pod(self):
@@ -210,8 +210,8 @@ class FromPodHostDiscovery(Discovery):
                 return True
         except requests.exceptions.ConnectionError:
             logger.debug("Failed to connect Azure metadata server")
-        except:
-            logger.debug(f"Unknown error when trying to connect to Azure metadata server")
+        except Exception:
+            logger.debug("Unknown error when trying to connect to Azure metadata server")
         return False
 
     # for pod scanning

--- a/kube_hunter/modules/discovery/hosts.py
+++ b/kube_hunter/modules/discovery/hosts.py
@@ -166,7 +166,9 @@ class FromPodHostDiscovery(Discovery):
                 return True
         except requests.exceptions.ConnectionError:
             logger.debug("Failed to connect AWS metadata server v1")
-            return False
+        except:
+            logger.debug(f"Unknown error when trying to connect to AWS metadata v1 API")
+        return False
 
     def is_aws_pod_v2(self):
         config = get_config()
@@ -189,7 +191,9 @@ class FromPodHostDiscovery(Discovery):
                 return True
         except requests.exceptions.ConnectionError:
             logger.debug("Failed to connect AWS metadata server v2")
-            return False
+        except:
+            logger.debug(f"Unknown error when trying to connect to AWS metadata v2 API")
+        return False
 
     def is_azure_pod(self):
         config = get_config()
@@ -206,7 +210,9 @@ class FromPodHostDiscovery(Discovery):
                 return True
         except requests.exceptions.ConnectionError:
             logger.debug("Failed to connect Azure metadata server")
-            return False
+        except:
+            logger.debug(f"Unknown error when trying to connect to Azure metadata server")
+        return False
 
     # for pod scanning
     def gateway_discovery(self):


### PR DESCRIPTION
## Description
Following #486
There seems to be an exception risen when requesting AWS metadata server when running under GKE clusters.
For some reason exception handling there was lacking, and caught only connection timeout Exceptions.

Now added general `except`  for all metadata api discoveries.

## Fixed Issues
Fixes #486 

## Contribution checklist
 - [ ] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
