### PR TITLE
Feature: Custom Hunting

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,11 @@ kube-hunter --custom <HunterName1> <HunterName2>
 ``` 
 Enabling Custom hunting removes all hunters from the hunting process, except the given whitelisted hunters.
 
-The `--custom` flag reads a list of hunters class names, in order to view all of kube-hunter's class names, you can combine the flag `--class-names` with the `--list` flag.  
+The `--custom` flag reads a list of hunters class names, in order to view all of kube-hunter's class names, you can combine the flag `--raw-hunter-names` with the `--list` flag.  
 
 Example: 
 ```
-kube-hunter --active --list --class-names
+kube-hunter --active --list --raw-hunter-names
 ```
 
 **Notice**: Due to kube-huner's architectural design, the following "Core Hunters/Classes" will always register (even when using custom hunting):

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Available dispatch methods are:
     * KUBEHUNTER_HTTP_DISPATCH_METHOD (defaults to: POST)
 
 
-## Advanced Usage 
+## Advanced Usage
 ### Azure Quick Scanning 
 When running **as a Pod in an Azure or AWS environment**, kube-hunter will fetch subnets from the Instance Metadata Service. Naturally this makes the discovery process take longer.
 To hardlimit subnet scanning to a `/24` CIDR, use the `--quick` option. 
@@ -180,10 +180,21 @@ Example:
 kube-hunter --active --list --class-names
 ```
 
-**Notice**: Due to kube-huner's architectural design, the following "Core Hunters" will always register (even when using custom hunting):
+**Notice**: Due to kube-huner's architectural design, the following "Core Hunters/Classes" will always register (even when using custom hunting):
+* HostDiscovery 
+  * _Generates ip addresses for the hunt by given configurations_
+  * _Automatically discovers subnets using cloud Metadata APIs_
 * FromPodHostDiscovery
-* HostDiscovery
+  * _Auto discover attack surface ip addresses for the hunt by using Pod based environment techniques_
+  * _Automatically discovers subnets using cloud Metadata APIs_
 * PortDiscovery
+  * _Port scanning given ip addresses for known kubernetes services ports_
+* Collector
+  * _Collects discovered vulnerabilities and open services for future report_
+* StartedInfo 
+  * _Prints the start message_
+* SendFullReport 
+  * _Dispatching the report based on given configurations_
 
 
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Table of Contents
 =================
 
 - [Table of Contents](#table-of-contents)
-  - [Kuberentes ATT&CK Matrix](#kuberentes-attck-matrix)
+  - [Kubernetes ATT&CK Matrix](#kubernetes-attck-matrix)
   - [Hunting](#hunting)
     - [Where should I run kube-hunter?](#where-should-i-run-kube-hunter)
     - [Scanning options](#scanning-options)
@@ -39,8 +39,9 @@ Table of Contents
     - [Nodes Mapping](#nodes-mapping)
     - [Output](#output)
     - [Dispatching](#dispatching)
-    - [Advanced Usage](#advanced-usage)
-      - [Azure Quick Scanning](#azure-quick-scanning)
+  - [Advanced Usage](#advanced-usage)
+    - [Azure Quick Scanning](#azure-quick-scanning)
+    - [Custom Hunting](#custom-hunting)
   - [Deployment](#deployment)
     - [On Machine](#on-machine)
       - [Prerequisites](#prerequisites)
@@ -53,6 +54,7 @@ Table of Contents
 
 ---
 ## Kubernetes ATT&CK Matrix
+
 kube-hunter now supports the new format of the Kubernetes ATT&CK matrix.
 While kube-hunter's vulnerabilities are a collection of creative techniques designed to mimic an attacker in the cluster (or outside it)
 The Mitre's ATT&CK defines a more general standardised categories of techniques to do so.
@@ -64,7 +66,6 @@ _Some kube-hunter vulnerabities which we could not map to Mitre technique, are p
 ![kube-hunter](./MITRE.png)
 
 ## Hunting
-
 ### Where should I run kube-hunter?
 
 There are three different ways to run kube-hunter, each providing a different approach to detecting weaknesses in your cluster:
@@ -157,10 +158,36 @@ Available dispatch methods are:
     * KUBEHUNTER_HTTP_DISPATCH_METHOD (defaults to: POST)
 
 
-### Advanced Usage 
-#### Azure Quick Scanning 
+## Advanced Usage 
+### Azure Quick Scanning 
 When running **as a Pod in an Azure or AWS environment**, kube-hunter will fetch subnets from the Instance Metadata Service. Naturally this makes the discovery process take longer.
 To hardlimit subnet scanning to a `/24` CIDR, use the `--quick` option. 
+
+### Custom Hunting
+Custom hunting enables advanced users to have control over what hunters gets registered at the start of a hunt. 
+**If you know what you are doing**, this can help if you want to adjust kube-hunter's hunting and discovery process for your needs.
+
+Example: 
+```
+kube-hunter --custom <HunterName1> <HunterName2>
+``` 
+Enabling Custom hunting removes all hunters from the hunting process, except the given whitelisted hunters.
+
+The `--custom` flag reads a list of hunters class names, in order to view all of kube-hunter's class names, you can combine the flag `--class-names` with the `--list` flag.  
+
+Example: 
+```
+kube-hunter --active --list --class-names
+```
+
+**Notice**: Due to kube-huner's architectural design, the following "Core Hunters" will always register (even when using custom hunting):
+* FromPodHostDiscovery
+* HostDiscovery
+* PortDiscovery
+
+
+
+
 
 ## Deployment
 There are three methods for deploying kube-hunter:

--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # flake8: noqa: E402
 
+from functools import partial
 import logging
 import threading
 
@@ -29,6 +30,7 @@ config = Config(
     service_account_token=args.service_account_token,
     kubeconfig=args.kubeconfig,
     enable_cve_hunting=args.enable_cve_hunting,
+    partial=args.partial
 )
 setup_logger(args.log, args.log_file)
 set_config(config)
@@ -73,16 +75,20 @@ def interactive_set_config():
     return True
 
 
-def list_hunters():
+def list_hunters(class_names=False):
     print("\nPassive Hunters:\n----------------")
     for hunter, docs in handler.passive_hunters.items():
         name, doc = hunter.parse_docs(docs)
+        if class_names:
+            name = hunter.__name__
         print(f"* {name}\n  {doc}\n")
 
     if config.active:
         print("\n\nActive Hunters:\n---------------")
         for hunter, docs in handler.active_hunters.items():
             name, doc = hunter.parse_docs(docs)
+            if class_names:
+                name = hunter.__name__
             print(f"* {name}\n  {doc}\n")
 
 
@@ -95,7 +101,10 @@ def main():
     scan_options = [config.pod, config.cidr, config.remote, config.interface, config.k8s_auto_discover_nodes]
     try:
         if args.list:
-            list_hunters()
+            if args.partial_names:
+                list_hunters(class_names=True)
+            else:
+                list_hunters()
             return
 
         if not any(scan_options):

--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -30,7 +30,7 @@ config = Config(
     service_account_token=args.service_account_token,
     kubeconfig=args.kubeconfig,
     enable_cve_hunting=args.enable_cve_hunting,
-    custom=args.custom
+    custom=args.custom,
 )
 setup_logger(args.log, args.log_file)
 set_config(config)

--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -30,7 +30,7 @@ config = Config(
     service_account_token=args.service_account_token,
     kubeconfig=args.kubeconfig,
     enable_cve_hunting=args.enable_cve_hunting,
-    partial=args.partial
+    custom=args.custom
 )
 setup_logger(args.log, args.log_file)
 set_config(config)
@@ -101,7 +101,7 @@ def main():
     scan_options = [config.pod, config.cidr, config.remote, config.interface, config.k8s_auto_discover_nodes]
     try:
         if args.list:
-            if args.partial_names:
+            if args.raw_hunter_names:
                 list_hunters(class_names=True)
             else:
                 list_hunters()

--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -47,8 +47,8 @@ class Config:
     service_account_token: Optional[str] = None
     kubeconfig: Optional[str] = None
     enable_cve_hunting: bool = False
-    partial: Optional[list] = None
-    partial_names: bool = False
+    custom: Optional[list] = None
+    raw_hunter_names: bool = False
     core_hunters: list = field(default_factory=get_default_core_hunters)
 
 

--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -1,6 +1,12 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
+def get_default_core_hunters():
+    return [
+        "FromPodHostDiscovery", 
+        "HostDiscovery",
+        "PortDiscovery"
+    ]
 
 @dataclass
 class Config:
@@ -41,10 +47,12 @@ class Config:
     service_account_token: Optional[str] = None
     kubeconfig: Optional[str] = None
     enable_cve_hunting: bool = False
+    partial: Optional[list] = None
+    partial_names: bool = False
+    core_hunters: list = field(default_factory=get_default_core_hunters)
 
 
 _config: Optional[Config] = None
-
 
 def get_config() -> Config:
     if not _config:

--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 
 def get_default_core_hunters():
-    return ["FromPodHostDiscovery", "HostDiscovery", "PortDiscovery"]
+    return ["FromPodHostDiscovery", "HostDiscovery", "PortDiscovery", "SendFullReport", "Collector", "StartedInfo"]
 
 
 @dataclass

--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -1,12 +1,10 @@
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+
 def get_default_core_hunters():
-    return [
-        "FromPodHostDiscovery", 
-        "HostDiscovery",
-        "PortDiscovery"
-    ]
+    return ["FromPodHostDiscovery", "HostDiscovery", "PortDiscovery"]
+
 
 @dataclass
 class Config:
@@ -53,6 +51,7 @@ class Config:
 
 
 _config: Optional[Config] = None
+
 
 def get_config() -> Config:
     if not _config:

--- a/kube_hunter/conf/parser.py
+++ b/kube_hunter/conf/parser.py
@@ -52,7 +52,8 @@ def parser_add_arguments(parser):
         nargs="+",
         metavar="HUNTERS",
         default=list(),
-        help="Custom hunting. Only given hunter names will register in the hunt. for a list of options run `--list --raw-hunter-names`",
+        help="Custom hunting. Only given hunter names will register in the hunt."
+        "for a list of options run `--list --raw-hunter-names`",
     )
 
     parser.add_argument(

--- a/kube_hunter/conf/parser.py
+++ b/kube_hunter/conf/parser.py
@@ -47,6 +47,21 @@ def parser_add_arguments(parser):
     )
 
     parser.add_argument(
+        "-p",
+        "--partial",
+        nargs="+",
+        metavar="HUNTERS",
+        default=list(),
+        help="Partial hunting. Only register given hunter names. for a list of options run `--list --partial-names`",
+    )
+
+    parser.add_argument(
+        "--partial-names",
+        action="store_true",
+        help="Use in combination with `--list` to display hunter class names to pass for partial hunting flag",
+    )
+
+    parser.add_argument(
         "--k8s-auto-discover-nodes",
         action="store_true",
         help="Enables automatic detection of all nodes in a Kubernetes cluster "

--- a/kube_hunter/conf/parser.py
+++ b/kube_hunter/conf/parser.py
@@ -47,18 +47,18 @@ def parser_add_arguments(parser):
     )
 
     parser.add_argument(
-        "-p",
-        "--partial",
+        "-c",
+        "--custom",
         nargs="+",
         metavar="HUNTERS",
         default=list(),
-        help="Partial hunting. Only register given hunter names. for a list of options run `--list --partial-names`",
+        help="Custom hunting. Only given hunter names will register in the hunt. for a list of options run `--list --raw-hunter-names`",
     )
 
     parser.add_argument(
-        "--partial-names",
+        "--raw-hunter-names",
         action="store_true",
-        help="Use in combination with `--list` to display hunter class names to pass for partial hunting flag",
+        help="Use in combination with `--list` to display hunter class names to pass for custom hunting flag",
     )
 
     parser.add_argument(

--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -267,21 +267,21 @@ class EventQueue(Queue):
         Returns true if:
          1. partial hunt is disabled
          2. partial hunt is enabled and hunter is in core hunter class
-         3. partial hunt is enabled and hunter is specified in config.partial 
+         3. partial hunt is enabled and hunter is specified in config.partial
 
         @param target_hunter: hunter class for registration check
-        """ 
+        """
         config = get_config()
         if not config.custom:
             return True
-        
+
         hunter_class_name = target_hunter.__name__
         if hunter_class_name in self.core_hunters or hunter_class_name in config.custom:
             return True
-            
+
         return False
 
-    def subscribe_event(self, event, hook=None, predicate=None, is_register=True):        
+    def subscribe_event(self, event, hook=None, predicate=None, is_register=True):
         if not is_register:
             return
         if not self.allowed_for_custom_registration(hook):

--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -15,8 +15,6 @@ logger = logging.getLogger(__name__)
 class EventQueue(Queue):
     def __init__(self, num_worker=10):
         super().__init__()
-        config = get_config()
-        self.core_hunters = config.core_hunters
         self.passive_hunters = dict()
         self.active_hunters = dict()
         self.all_hunters = dict()
@@ -262,7 +260,7 @@ class EventQueue(Queue):
     def allowed_for_custom_registration(self, target_hunter):
         """
         Check if the partial input list contains the hunter we are about to register for events
-        If hunter is considered a Core hunter as specified in `self.core_hunters` we allow it anyway
+        If hunter is considered a Core hunter as specified in `config.core_hunters` we allow it anyway
 
         Returns true if:
          1. partial hunt is disabled
@@ -276,7 +274,7 @@ class EventQueue(Queue):
             return True
 
         hunter_class_name = target_hunter.__name__
-        if hunter_class_name in self.core_hunters or hunter_class_name in config.custom:
+        if hunter_class_name in config.core_hunters or hunter_class_name in config.custom:
             return True
 
         return False

--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 class EventQueue(Queue):
     def __init__(self, num_worker=10):
         super().__init__()
+        config = get_config()
+        self.core_hunters = config.core_hunters
         self.passive_hunters = dict()
         self.active_hunters = dict()
         self.all_hunters = dict()
@@ -257,8 +259,32 @@ class EventQueue(Queue):
             self.hooks[event].append((hook, predicate))
             logging.debug("{} subscribed to {}".format(hook, event))
 
-    def subscribe_event(self, event, hook=None, predicate=None, is_register=True):
+    def allowed_for_partial_registration(self, target_hunter):
+        """
+        Check if the partial input list contains the hunter we are about to register for events
+        If hunter is considered a Core hunter as specified in `self.core_hunters` we allow it anyway
+
+        Returns true if:
+         1. partial hunt is disabled
+         2. partial hunt is enabled and hunter is in core hunter class
+         3. partial hunt is enabled and hunter is specified in config.partial 
+
+        @param target_hunter: hunter class for registration check
+        """ 
+        config = get_config()
+        if not config.partial:
+            return True
+        
+        hunter_class_name = target_hunter.__name__
+        if hunter_class_name in self.core_hunters or hunter_class_name in config.partial:
+            return True
+            
+        return False
+
+    def subscribe_event(self, event, hook=None, predicate=None, is_register=True):        
         if not is_register:
+            return
+        if not self.allowed_for_partial_registration(hook):
             return
         if not self._register_hunters(hook):
             return
@@ -272,9 +298,11 @@ class EventQueue(Queue):
 
     def subscribe_events(self, events, hook=None, predicates=None, is_register=True):
         if not is_register:
-            return False
+            return
+        if not self.allowed_for_partial_registration(hook):
+            return
         if not self._register_hunters(hook):
-            return False
+            return
 
         if predicates is None:
             predicates = [None] * len(events)

--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -259,7 +259,7 @@ class EventQueue(Queue):
             self.hooks[event].append((hook, predicate))
             logging.debug("{} subscribed to {}".format(hook, event))
 
-    def allowed_for_partial_registration(self, target_hunter):
+    def allowed_for_custom_registration(self, target_hunter):
         """
         Check if the partial input list contains the hunter we are about to register for events
         If hunter is considered a Core hunter as specified in `self.core_hunters` we allow it anyway
@@ -272,11 +272,11 @@ class EventQueue(Queue):
         @param target_hunter: hunter class for registration check
         """ 
         config = get_config()
-        if not config.partial:
+        if not config.custom:
             return True
         
         hunter_class_name = target_hunter.__name__
-        if hunter_class_name in self.core_hunters or hunter_class_name in config.partial:
+        if hunter_class_name in self.core_hunters or hunter_class_name in config.custom:
             return True
             
         return False
@@ -284,7 +284,7 @@ class EventQueue(Queue):
     def subscribe_event(self, event, hook=None, predicate=None, is_register=True):        
         if not is_register:
             return
-        if not self.allowed_for_partial_registration(hook):
+        if not self.allowed_for_custom_registration(hook):
             return
         if not self._register_hunters(hook):
             return
@@ -299,7 +299,7 @@ class EventQueue(Queue):
     def subscribe_events(self, events, hook=None, predicates=None, is_register=True):
         if not is_register:
             return
-        if not self.allowed_for_partial_registration(hook):
+        if not self.allowed_for_custom_registration(hook):
             return
         if not self._register_hunters(hook):
             return

--- a/kube_hunter/modules/report/dispatchers.py
+++ b/kube_hunter/modules/report/dispatchers.py
@@ -12,11 +12,7 @@ class HTTPDispatcher:
         dispatch_url = os.environ.get("KUBEHUNTER_HTTP_DISPATCH_URL", "https://localhost/")
         try:
             r = requests.request(
-                dispatch_method,
-                dispatch_url,
-                json=report,
-                headers={"Content-Type": "application/json"},
-                verify=False
+                dispatch_method, dispatch_url, json=report, headers={"Content-Type": "application/json"}, verify=False
             )
             r.raise_for_status()
             logger.info(f"Report was dispatched to: {dispatch_url}")


### PR DESCRIPTION
## Description
This feature enables advanced users to explicitly specify which hunters they want kube-hunter to register.
Now 

### Added:
* New flag `--custom` flag that receives a list of hunter class names to whitelist the registration process 
* New flag `--raw-hunter-names` to use in conjunction with `--list` in order to view Hunter class names, to use with the custom feature
* Documentaion regarding the new "Custom Hunting" feature

### Internal changes:
* new config field specifying `core_hunters` which will always register. 
* the logic is in `handles.py` and is now running at the start of every register operation, to check whether custom hunt is enabled, and if so checks the whitelisted hunters. this is done by the new method: `allowed_for_custom_registration(target_hunter)` in the event queue object

### The future
Due to the complexity of kube-hunter's event handling. it is hard to create a custom hunt by a given wanted end result (Some vulnerability to check)

I want us to add a mapping for every hunter of what vulnerabilities it might produce, by that we can then generate a decision tree by which we can automatically register all of the hunters responsible to output such end vulnerability.
This will result in an easy advanced custom hunting, which would allow users to only use partial logic in kube-hunter, without having to know class names.

### BEFORE
```bash
$ kube-hunter --log debug
2022-01-28 18:02:18,049 DEBUG root <class 'kube_hunter.modules.report.collector.Collector'> subscribed to <class 'kube_hunter.core.events.types.Vulnerability'>
2022-01-28 18:02:18,049 DEBUG root <class 'kube_hunter.modules.report.collector.Collector'> subscribed to <class 'kube_hunter.core.events.types.Service'>
2022-01-28 18:02:18,049 DEBUG root <class 'kube_hunter.modules.report.collector.SendFullReport'> subscribed to <class 'kube_hunter.core.events.types.HuntFinished'>
2022-01-28 18:02:18,050 DEBUG root <class 'kube_hunter.modules.report.collector.StartedInfo'> subscribed to <class 'kube_hunter.core.events.types.HuntStarted'>
2022-01-28 18:02:18,129 DEBUG root <class 'kube_hunter.modules.discovery.apiserver.ApiServiceDiscovery'> subscribed to <class 'kube_hunter.core.events.types.OpenPortEvent'>
2022-01-28 18:02:18,129 DEBUG root <class 'kube_hunter.modules.discovery.apiserver.ApiServiceClassify'> filter subscribed to <class 'kube_hunter.modules.discovery.apiserver.K8sApiService'>
2022-01-28 18:02:18,131 DEBUG root <class 'kube_hunter.modules.discovery.dashboard.KubeDashboard'> subscribed to <class 'kube_hunter.core.events.types.OpenPortEvent'>
2022-01-28 18:02:18,133 DEBUG root <class 'kube_hunter.modules.discovery.etcd.EtcdRemoteAccess'> subscribed to <class 'kube_hunter.core.events.types.OpenPortEvent'>
2022-01-28 18:02:20,266 DEBUG root <class 'kube_hunter.modules.discovery.hosts.FromPodHostDiscovery'> subscribed to <class 'kube_hunter.modules.discovery.hosts.RunningAsPodEvent'>
2022-01-28 18:02:20,267 DEBUG root <class 'kube_hunter.modules.discovery.hosts.HostDiscovery'> subscribed to <class 'kube_hunter.modules.discovery.hosts.HostScanEvent'>
2022-01-28 18:02:20,270 DEBUG root <class 'kube_hunter.modules.discovery.kubectl.KubectlClientDiscovery'> subscribed to <class 'kube_hunter.core.events.types.HuntStarted'>
2022-01-28 18:02:20,272 DEBUG root <class 'kube_hunter.modules.discovery.kubelet.KubeletDiscovery'> subscribed to <class 'kube_hunter.core.events.types.OpenPortEvent'>
2022-01-28 18:02:20,275 DEBUG root <class 'kube_hunter.modules.discovery.ports.PortDiscovery'> subscribed to <class 'kube_hunter.core.events.types.NewHostEvent'>
2022-01-28 18:02:20,280 DEBUG root <class 'kube_hunter.modules.discovery.proxy.KubeProxy'> subscribed to <class 'kube_hunter.core.events.types.OpenPortEvent'>
```

### AFTER
```bash
$ kube-hunter --log debug --custom ""
2022-01-28 18:11:28,106 DEBUG root <class 'kube_hunter.modules.report.collector.Collector'> subscribed to <class 'kube_hunter.core.events.types.Vulnerability'>
2022-01-28 18:11:28,106 DEBUG root <class 'kube_hunter.modules.report.collector.Collector'> subscribed to <class 'kube_hunter.core.events.types.Service'>
2022-01-28 18:11:28,106 DEBUG root <class 'kube_hunter.modules.report.collector.SendFullReport'> subscribed to <class 'kube_hunter.core.events.types.HuntFinished'>
2022-01-28 18:11:28,107 DEBUG root <class 'kube_hunter.modules.report.collector.StartedInfo'> subscribed to <class 'kube_hunter.core.events.types.HuntStarted'>
2022-01-28 18:11:29,268 DEBUG root <class 'kube_hunter.modules.discovery.hosts.FromPodHostDiscovery'> subscribed to <class 'kube_hunter.modules.discovery.hosts.RunningAsPodEvent'>
2022-01-28 18:11:29,268 DEBUG root <class 'kube_hunter.modules.discovery.hosts.HostDiscovery'> subscribed to <class 'kube_hunter.modules.discovery.hosts.HostScanEvent'>
2022-01-28 18:11:29,272 DEBUG root <class 'kube_hunter.modules.discovery.ports.PortDiscovery'> subscribed to <class 'kube_hunter.core.events.types.NewHostEvent'>
```

## Contribution checklist
 - [ ] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
