### PR TITLE
Added severity to the kube-hunter found issues

### DIFF
--- a/docs/_kb/KHV002.md
+++ b/docs/_kb/KHV002.md
@@ -2,6 +2,7 @@
 vid: KHV002
 title: Kubernetes version disclosure
 categories: [Information Disclosure]
+severity: LOW
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV003.md
+++ b/docs/_kb/KHV003.md
@@ -2,6 +2,7 @@
 vid: KHV003
 title: Azure Metadata Exposure
 categories: [Information Disclosure]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV004.md
+++ b/docs/_kb/KHV004.md
@@ -2,6 +2,7 @@
 vid: KHV004
 title: Azure SPN Exposure
 categories: [Identity Theft]
+severity: MEDIUM
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV005.md
+++ b/docs/_kb/KHV005.md
@@ -2,6 +2,7 @@
 vid: KHV005
 title: Access to Kubernetes API
 categories: [Information Disclosure, Unauthenticated Access]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV006.md
+++ b/docs/_kb/KHV006.md
@@ -2,6 +2,7 @@
 vid: KHV006
 title: Insecure (HTTP) access to Kubernetes API
 categories: [Unauthenticated Access]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV007.md
+++ b/docs/_kb/KHV007.md
@@ -2,6 +2,7 @@
 vid: KHV007
 title: Specific Access to Kubernetes API
 categories: [Access Risk]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV020.md
+++ b/docs/_kb/KHV020.md
@@ -2,6 +2,7 @@
 vid: KHV020
 title: Possible Arp Spoof
 categories: [IdentityTheft]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV021.md
+++ b/docs/_kb/KHV021.md
@@ -2,6 +2,7 @@
 vid: KHV021
 title: Certificate Includes Email Address
 categories: [Information Disclosure]
+severity: LOW
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV022.md
+++ b/docs/_kb/KHV022.md
@@ -2,6 +2,7 @@
 vid: KHV022
 title: Critical Privilege Escalation CVE
 categories: [Privilege Escalation]
+severity: CRITICAL
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV023.md
+++ b/docs/_kb/KHV023.md
@@ -2,6 +2,7 @@
 vid: KHV023
 title: Denial of Service to Kubernetes API Server
 categories: [Denial Of Service]
+severity: MEDIUM
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV024.md
+++ b/docs/_kb/KHV024.md
@@ -2,6 +2,7 @@
 vid: KHV024
 title: Possible Ping Flood Attack
 categories: [Denial Of Service]
+severity: MEDIUM
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV025.md
+++ b/docs/_kb/KHV025.md
@@ -2,6 +2,7 @@
 vid: KHV025
 title: Possible Reset Flood Attack
 categories: [Denial Of Service]
+severity: MEDIUM
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV026.md
+++ b/docs/_kb/KHV026.md
@@ -2,6 +2,7 @@
 vid: KHV026
 title: Arbitrary Access To Cluster Scoped Resources
 categories: [PrivilegeEscalation]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV027.md
+++ b/docs/_kb/KHV027.md
@@ -2,6 +2,7 @@
 vid: KHV027
 title: Kubectl Vulnerable To CVE-2019-11246
 categories: [Remote Code Execution]
+severity: MEDIUM
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV028.md
+++ b/docs/_kb/KHV028.md
@@ -2,6 +2,7 @@
 vid: KHV028
 title: Kubectl Vulnerable To CVE-2019-1002101
 categories: [Remote Code Execution]
+severity: MEDIUM
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV029.md
+++ b/docs/_kb/KHV029.md
@@ -2,6 +2,7 @@
 vid: KHV029
 title: Dashboard Exposed
 categories: [Remote Code Execution]
+severity: CRITICAL
 ---
 
 # {{ page.vid }} - {{ page.title }}
@@ -13,3 +14,4 @@ An open Kubernetes Dashboard was detected. The Kubernetes Dashboard can be used 
 ## Remediation
 
 Do not leave the Dashboard insecured.
+

--- a/docs/_kb/KHV030.md
+++ b/docs/_kb/KHV030.md
@@ -2,6 +2,7 @@
 vid: KHV030
 title: Possible DNS Spoof
 categories: [Identity Theft]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV031.md
+++ b/docs/_kb/KHV031.md
@@ -2,6 +2,7 @@
 vid: KHV031
 title: Etcd Remote Write Access Event
 categories: [Remote Code Execution]
+severity: CRITICAL
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV032.md
+++ b/docs/_kb/KHV032.md
@@ -2,6 +2,7 @@
 vid: KHV032
 title: Etcd Remote Read Access Event
 categories: [Access Risk]
+severity: CRITICAL
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV033.md
+++ b/docs/_kb/KHV033.md
@@ -2,6 +2,7 @@
 vid: KHV033
 title: Etcd Remote version disclosure
 categories: [Information Disclosure]
+severity: MEDIUM
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV034.md
+++ b/docs/_kb/KHV034.md
@@ -2,6 +2,7 @@
 vid: KHV034
 title: Etcd is accessible using insecure connection (HTTP)
 categories: [Unauthenticated Access]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV036.md
+++ b/docs/_kb/KHV036.md
@@ -2,6 +2,7 @@
 vid: KHV036
 title: Anonymous Authentication
 categories: [Remote Code Execution]
+severity: CRITICAL
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV037.md
+++ b/docs/_kb/KHV037.md
@@ -2,6 +2,7 @@
 vid: KHV037
 title: Exposed Container Logs
 categories: [Information Disclosure]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV038.md
+++ b/docs/_kb/KHV038.md
@@ -2,6 +2,7 @@
 vid: KHV038
 title: Exposed Running Pods
 categories: [Information Disclosure]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV039.md
+++ b/docs/_kb/KHV039.md
@@ -2,6 +2,7 @@
 vid: KHV039
 title: Exposed Exec On Container
 categories: [Remote Code Execution]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV040.md
+++ b/docs/_kb/KHV040.md
@@ -2,6 +2,7 @@
 vid: KHV040
 title: Exposed Run Inside Container
 categories: [Remote Code Execution]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV041.md
+++ b/docs/_kb/KHV041.md
@@ -2,6 +2,7 @@
 vid: KHV041
 title: Exposed Port Forward
 categories: [Remote Code Execution]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV042.md
+++ b/docs/_kb/KHV042.md
@@ -2,6 +2,7 @@
 vid: KHV042
 title: Exposed Attaching To Container
 categories: [Remote Code Execution]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV043.md
+++ b/docs/_kb/KHV043.md
@@ -2,6 +2,7 @@
 vid: KHV043
 title: Cluster Health Disclosure
 categories: [Information Disclosure]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV044.md
+++ b/docs/_kb/KHV044.md
@@ -2,6 +2,7 @@
 vid: KHV044
 title: Privileged Container
 categories: [Access Risk]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV045.md
+++ b/docs/_kb/KHV045.md
@@ -2,6 +2,7 @@
 vid: KHV045
 title: Exposed System Logs
 categories: [Information Disclosure]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV046.md
+++ b/docs/_kb/KHV046.md
@@ -2,6 +2,7 @@
 vid: KHV046
 title: Exposed Kubelet Cmdline
 categories: [Information Disclosure]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV047.md
+++ b/docs/_kb/KHV047.md
@@ -2,6 +2,7 @@
 vid: KHV047
 title: Pod With Mount To /var/log
 categories: [Privilege Escalation]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV049.md
+++ b/docs/_kb/KHV049.md
@@ -2,6 +2,7 @@
 vid: KHV049
 title: kubectl proxy Exposed
 categories: [Information Disclosure]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV050.md
+++ b/docs/_kb/KHV050.md
@@ -2,6 +2,7 @@
 vid: KHV050
 title: Read access to Pod service account token
 categories: [Access Risk]
+severity: MEDIUM
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV051.md
+++ b/docs/_kb/KHV051.md
@@ -2,6 +2,7 @@
 vid: KHV051
 title: Exposed Existing Privileged Containers Via Secure Kubelet Port
 categories: [Access Risk]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV052.md
+++ b/docs/_kb/KHV052.md
@@ -2,6 +2,7 @@
 vid: KHV052
 title: Exposed Pods
 categories: [Information Disclosure]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV053.md
+++ b/docs/_kb/KHV053.md
@@ -2,6 +2,7 @@
 vid: KHV053
 title: AWS Metadata Exposure
 categories: [Information Disclosure]
+severity: HIGH
 ---
 
 # {{ page.vid }} - {{ page.title }}


### PR DESCRIPTION
## Description
I've added severities to the kube-hunter findings. Severity can be critical, high, medium and low.
These severities are shown in the AVD (avs.aquasec.com) website.

