### PR TITLE
Fixes: Make thread count configurable #433 #426

### DIFF
--- a/kube_hunter/__main__.py
+++ b/kube_hunter/__main__.py
@@ -22,6 +22,7 @@ config = Config(
     log_file=args.log_file,
     mapping=args.mapping,
     network_timeout=args.network_timeout,
+    num_worker_threads=args.num_worker_threads,
     pod=args.pod,
     quick=args.quick,
     remote=args.remote,

--- a/kube_hunter/conf/__init__.py
+++ b/kube_hunter/conf/__init__.py
@@ -20,6 +20,7 @@ class Config:
     - log_file: Log File path
     - mapping: Report only found components
     - network_timeout: Timeout for network operations
+    - num_worker_threads: Add a flag --threads to change the default 800 thread count of the event handler
     - pod: From pod scanning mode
     - quick: Quick scanning mode
     - remote: Hosts to scan
@@ -36,6 +37,7 @@ class Config:
     log_file: Optional[str] = None
     mapping: bool = False
     network_timeout: float = 5.0
+    num_worker_threads: int = 800
     pod: bool = False
     quick: bool = False
     remote: Optional[str] = None

--- a/kube_hunter/conf/parser.py
+++ b/kube_hunter/conf/parser.py
@@ -133,6 +133,11 @@ def parser_add_arguments(parser):
 
     parser.add_argument("--network-timeout", type=float, default=5.0, help="network operations timeout")
 
+    parser.add_argument("--num-worker-threads", type=int, default=800,
+                        help="In some environments the default thread count of 800 is too much. "
+                             "This crashes the process when trying to open more threads."
+                             "In that case feel free to try a lower number, like 400 for example.")
+
 
 def parse_args(add_args_hook):
     """

--- a/kube_hunter/core/events/handler.py
+++ b/kube_hunter/core/events/handler.py
@@ -366,4 +366,5 @@ class EventQueue(Queue):
             self.queue.clear()
 
 
-handler = EventQueue(800)
+config = get_config()
+handler = EventQueue(config.num_worker_threads)


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
We experienced the same issue, we needed to make the thread count configurable. 800 is to much for us as wel.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/main/CONTRIBUTING.md).

## Fixed Issues

Please mention any issues fixed in the PR by referencing it properly in the commit message.
As per the convention, use appropriate keywords such as `fixes`, `closes`, `resolves` to automatically refer the issue.
Please consult [official github documentation](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) for details.

Fixes #433 & 
Fixes #426 

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

### BEFORE
No terminal output

### AFTER
No terminal output

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [-] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
