### PR TITLE
Changed help message of --num-worker-threads flag

### DIFF
--- a/kube_hunter/conf/parser.py
+++ b/kube_hunter/conf/parser.py
@@ -133,10 +133,13 @@ def parser_add_arguments(parser):
 
     parser.add_argument("--network-timeout", type=float, default=5.0, help="network operations timeout")
 
-    parser.add_argument("--num-worker-threads", type=int, default=800,
-                        help="In some environments the default thread count of 800 is too much. "
-                             "This crashes the process when trying to open more threads."
-                             "In that case feel free to try a lower number, like 400 for example.")
+    parser.add_argument(
+        "--num-worker-threads",
+        type=int,
+        default=800,
+        help="In some environments the default thread count (800) can cause the process to crash. "
+        "In the case of a crash try lowering the thread count",
+    )
 
 
 def parse_args(add_args_hook):

--- a/tests/core/test_cloud.py
+++ b/tests/core/test_cloud.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E402
 import requests_mock
 import json
 

--- a/tests/core/test_cloud.py
+++ b/tests/core/test_cloud.py
@@ -2,9 +2,10 @@ import requests_mock
 import json
 
 from kube_hunter.conf import Config, set_config
-from kube_hunter.core.events.types import NewHostEvent
 
 set_config(Config())
+
+from kube_hunter.core.events.types import NewHostEvent
 
 
 def test_presetcloud():


### PR DESCRIPTION
## Description
Following #433 added a minor change in the help message of the flag.

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [x] I have added automated testing to cover this case.
 