### PR TITLE
pin image version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
       - name: Get version
         id: get_version
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: crazy-max/ghaction-docker-meta@v3
         with:
           images: ${{ env.REP }}
           tag-semver: |

--- a/job.yaml
+++ b/job.yaml
@@ -5,11 +5,13 @@ metadata:
   name: kube-hunter
 spec:
   template:
+    metadata:
+      labels:
+        app: kube-hunter
     spec:
       containers:
         - name: kube-hunter
-          image: aquasec/kube-hunter
+          image: aquasec/kube-hunter:v0.6.7
           command: ["kube-hunter"]
           args: ["--pod"]
       restartPolicy: Never
-  backoffLimit: 4

--- a/job.yaml
+++ b/job.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: kube-hunter
-          image: aquasec/kube-hunter:0.6.7
+          image: aquasec/kube-hunter:v0.6.7
           command: ["kube-hunter"]
           args: ["--pod"]
       restartPolicy: Never

--- a/job.yaml
+++ b/job.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: kube-hunter
-          image: aquasec/kube-hunter:v0.6.7
+          image: aquasec/kube-hunter:0.6.7
           command: ["kube-hunter"]
           args: ["--pod"]
       restartPolicy: Never


### PR DESCRIPTION
## Description

This pins the image version in the job manifest. Using this manifest directly (for example  `kubectl apply -f https://raw.githubusercontent.com/aquasecurity/kube-hunter/v0.6.7/job.yaml`) on a pinned version, will allow using that manifest without having to maintain your own, and allowing changes to this repo without breaking a pipeline.

For example, using the job manifest now will fail because of #502 , and there's no previous manifest to refer to.

### Version tag discrepancy

I've also upped the semver tagging in the GitHub actions to coincide with the `kube-bench` format (as well as the format in the tags of this repo). Using the job manifest now will fail, as it first needs to publish with the new tag format.

This shouldn't impact any existing setups, as latest will stay as it is, and older tags will remain as they are.

### Other

Also added label for the pod, and removed backofflimit to just use the default of 6. Cleaner and the same as `kube-bench`.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/main/CONTRIBUTING.md).

## Fixed Issues

Did not make an issue.

## "BEFORE" and "AFTER" output

No terminal output changes

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
