### PR TITLE
discovery: Make kubectl.py able to find kubectl

### DIFF
--- a/kube_hunter/modules/discovery/kubectl.py
+++ b/kube_hunter/modules/discovery/kubectl.py
@@ -32,7 +32,7 @@ class KubectlClientDiscovery(Discovery):
         version = None
         try:
             # kubectl version --client does not make any connection to the cluster/internet whatsoever.
-            version_info = subprocess.check_output("kubectl version --client", stderr=subprocess.STDOUT)
+            version_info = subprocess.check_output(["kubectl", "version", "--client"], stderr=subprocess.STDOUT)
             if b"GitVersion" in version_info:
                 # extracting version from kubectl output
                 version_info = version_info.decode()


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description

I was trying to get kube-hunter to display something about the remote k3s cluster with only port 6443 accessible.
While doing so I saw in the debug log output that it couldn't find kubectl, even though it's in $PATH

Doing so I eventually made conclusion that the arguments in subprocess check_output function in python 3.8.10 needs to be a
list. I do not know if this has changed in python. There might be better ways to change this. At least this change makes the code find the kubectl version.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/main/CONTRIBUTING.md).

## Fixed Issues


Fixes #(issue)

## "BEFORE" and "AFTER" output

### BEFORE



Before the change the error in "--log debug" would look like:

```
2022-06-03 13:54:56,497 DEBUG kube_hunter.modules.discovery.kubectl Could not find kubectl client
```



### AFTER

And if I add small code change to also print the exception error it
prints:
```
2022-06-03 13:54:56,497 DEBUG kube_hunter.modules.discovery.kubectl [Errno 2] No such file or directory: 'kubectl version --client'
2022-06-03 13:54:56,497 DEBUG kube_hunter.modules.discovery.kubectl Could not find kubectl client
```

## Contribution checklist
 - [ ] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
