### PR TITLE
Removing netifaces due to lack of maintainer

### DIFF
--- a/kube_hunter/modules/discovery/hosts.py
+++ b/kube_hunter/modules/discovery/hosts.py
@@ -141,7 +141,7 @@ class FromPodHostDiscovery(Discovery):
 
             gateway_subnet = self.gateway_discovery()
             if gateway_subnet:
-                subnets += gateway_subnet
+                subnets.append(gateway_subnet)
 
             should_scan_apiserver = False
             if self.event.kubeservicehost:
@@ -237,7 +237,8 @@ class FromPodHostDiscovery(Discovery):
                 ip.release()
         else:
             logging.debug("Not running in a linux env, will not scan default subnet")
-            return False
+        
+        return False
 
     # querying AWS's interface metadata api v1 | works only from a pod
     def aws_metadata_v1_discovery(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ zip_safe = False
 packages = find:
 install_requires =
     netaddr
-    netifaces
+    psutil
     requests
     PrettyTable
     urllib3>=1.24.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ zip_safe = False
 packages = find:
 install_requires =
     netaddr
-    psutil
+    pyroute2
     requests
     PrettyTable
     urllib3>=1.24.3


### PR DESCRIPTION
## Description
This issue arose due to the lack of maintainer for the `netifaces` package.
in this PR we remove it's usage completely.

now using the pyroute2 package for linux and a powershell snippet for windows, as suggested by @newtondev in #516 . Thanks!
the library is dual licensed so we can use it under the Apache 2 license.

the only downside for this is the necessity _for the time being_ to **remove support for running in pod mode in a windows host**.
Anyway we didn't came across a real need for this in production environments. so let us know if u require this support in the future.

## Fixed Issues
fixes #516 

## Contribution checklist
 - [ ] I have read the Contributing Guidelines.
 - [ ] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.
