### PR TITLE
fix the bug of k8s node duplication due to the lack of judgment of th…

### DIFF
--- a/kube_hunter/modules/discovery/kubernetes_client.py
+++ b/kube_hunter/modules/discovery/kubernetes_client.py
@@ -22,6 +22,7 @@ def list_all_k8s_cluster_nodes(kube_config=None, client=None):
         logger.info("Listed %d nodes in the cluster" % len(ret.items))
         for item in ret.items:
             for addr in item.status.addresses:
-                yield addr.address
+                if addr.type == "InternalIP":
+                    yield addr.address
     except Exception as ex:
         logger.debug(f"Failed to list nodes from Kubernetes: {ex}")


### PR DESCRIPTION
## Description
In order to avoid duplication of detected nodes, services and vulnerabilities, we need to determine the type of node address when the k8s cluster node is automatically found.


## Fixed Issues
Fixes #527

## "BEFORE" and "AFTER" output
### BEFORE
```bash
./kube-hunter.py --k8s-auto-discover-nodes --kubeconfig /root/.kube/config
2022-11-11 02:48:11,574 INFO kube_hunter.modules.report.collector Started hunting
2022-11-11 02:48:11,574 INFO kube_hunter.modules.report.collector Discovering Open Kubernetes Services
2022-11-11 02:48:11,685 INFO kube_hunter.modules.discovery.kubernetes_client Listed 1 nodes in the cluster
2022-11-11 02:48:11,697 INFO kube_hunter.modules.report.collector Found open service "Etcd" at 192.168.1.133:2379
2022-11-11 02:48:11,721 INFO kube_hunter.modules.report.collector Found open service "Etcd" at k8s:2379
2022-11-11 02:48:11,815 INFO kube_hunter.modules.report.collector Found vulnerability "K8s Version Disclosure" in 192.168.1.133:6443
2022-11-11 02:48:11,820 INFO kube_hunter.modules.report.collector Found open service "API Server" at k8s:6443
2022-11-11 02:48:11,824 INFO kube_hunter.modules.report.collector Found vulnerability "K8s Version Disclosure" in k8s:6443
2022-11-11 02:48:11,831 INFO kube_hunter.modules.report.collector Found open service "API Server" at 192.168.1.133:6443
2022-11-11 02:48:11,928 INFO kube_hunter.modules.report.collector Found open service "Kubelet API" at 192.168.1.133:10250
2022-11-11 02:48:11,932 INFO kube_hunter.modules.report.collector Found open service "Kubelet API" at k8s:10250

Nodes
+-------------+---------------+
| TYPE        | LOCATION      |
+-------------+---------------+
| Node/Master | k8s           |
+-------------+---------------+
| Node/Master | 192.168.1.133 |
+-------------+---------------+

Detected Services
+-------------+---------------------+----------------------+
| SERVICE     | LOCATION            | DESCRIPTION          |
+-------------+---------------------+----------------------+
| Kubelet API | k8s:10250           | The Kubelet is the   |
|             |                     | main component in    |
|             |                     | every Node, all pod  |
|             |                     | operations goes      |
|             |                     | through the kubelet  |
+-------------+---------------------+----------------------+
| Kubelet API | 192.168.1.133:10250 | The Kubelet is the   |
|             |                     | main component in    |
|             |                     | every Node, all pod  |
|             |                     | operations goes      |
|             |                     | through the kubelet  |
+-------------+---------------------+----------------------+
| Etcd        | k8s:2379            | Etcd is a DB that    |
|             |                     | stores cluster's     |
|             |                     | data, it contains    |
|             |                     | configuration and    |
|             |                     | current              |
|             |                     |     state            |
|             |                     | information, and     |
|             |                     | might contain        |
|             |                     | secrets              |
+-------------+---------------------+----------------------+
| Etcd        | 192.168.1.133:2379  | Etcd is a DB that    |
|             |                     | stores cluster's     |
|             |                     | data, it contains    |
|             |                     | configuration and    |
|             |                     | current              |
|             |                     |     state            |
|             |                     | information, and     |
|             |                     | might contain        |
|             |                     | secrets              |
+-------------+---------------------+----------------------+
| API Server  | k8s:6443            | The API server is in |
|             |                     | charge of all        |
|             |                     | operations on the    |
|             |                     | cluster.             |
+-------------+---------------------+----------------------+
| API Server  | 192.168.1.133:6443  | The API server is in |
|             |                     | charge of all        |
|             |                     | operations on the    |
|             |                     | cluster.             |
+-------------+---------------------+----------------------+

Vulnerabilities
For further information about a vulnerability, search its ID in:
https://avd.aquasec.com/
+--------+--------------------+----------------------+----------------------+----------------------+----------+
| ID     | LOCATION           | MITRE CATEGORY       | VULNERABILITY        | DESCRIPTION          | EVIDENCE |
+--------+--------------------+----------------------+----------------------+----------------------+----------+
| KHV002 | k8s:6443           | Initial Access //    | K8s Version          | The kubernetes       | v1.23.7  |
|        |                    | Exposed sensitive    | Disclosure           | version could be     |          |
|        |                    | interfaces           |                      | obtained from the    |          |
|        |                    |                      |                      | /version endpoint    |          |
+--------+--------------------+----------------------+----------------------+----------------------+----------+
| KHV002 | 192.168.1.133:6443 | Initial Access //    | K8s Version          | The kubernetes       | v1.23.7  |
|        |                    | Exposed sensitive    | Disclosure           | version could be     |          |
|        |                    | interfaces           |                      | obtained from the    |          |
|        |                    |                      |                      | /version endpoint    |          |
+--------+--------------------+----------------------+----------------------+----------------------+----------+
```
### AFTER
```bash
./kube-hunter.py --k8s-auto-discover-nodes --kubeconfig /root/.kube/config
2022-11-11 03:18:23,914 INFO kube_hunter.modules.report.collector Started hunting
2022-11-11 03:18:23,925 INFO kube_hunter.modules.report.collector Discovering Open Kubernetes Services
2022-11-11 03:18:23,971 INFO kube_hunter.modules.discovery.kubernetes_client Listed 1 nodes in the cluster
2022-11-11 03:18:23,975 INFO kube_hunter.modules.report.collector Found open service "Etcd" at 192.168.1.133:2379
2022-11-11 03:18:24,015 INFO kube_hunter.modules.report.collector Found open service "Kubelet API" at 192.168.1.133:10250
2022-11-11 03:18:24,056 INFO kube_hunter.modules.report.collector Found open service "API Server" at 192.168.1.133:6443
2022-11-11 03:18:24,056 INFO kube_hunter.modules.report.collector Found vulnerability "K8s Version Disclosure" in 192.168.1.133:6443

Nodes
+-------------+---------------+
| TYPE        | LOCATION      |
+-------------+---------------+
| Node/Master | 192.168.1.133 |
+-------------+---------------+

Detected Services
+-------------+---------------------+----------------------+
| SERVICE     | LOCATION            | DESCRIPTION          |
+-------------+---------------------+----------------------+
| Kubelet API | 192.168.1.133:10250 | The Kubelet is the   |
|             |                     | main component in    |
|             |                     | every Node, all pod  |
|             |                     | operations goes      |
|             |                     | through the kubelet  |
+-------------+---------------------+----------------------+
| Etcd        | 192.168.1.133:2379  | Etcd is a DB that    |
|             |                     | stores cluster's     |
|             |                     | data, it contains    |
|             |                     | configuration and    |
|             |                     | current              |
|             |                     |     state            |
|             |                     | information, and     |
|             |                     | might contain        |
|             |                     | secrets              |
+-------------+---------------------+----------------------+
| API Server  | 192.168.1.133:6443  | The API server is in |
|             |                     | charge of all        |
|             |                     | operations on the    |
|             |                     | cluster.             |
+-------------+---------------------+----------------------+

Vulnerabilities
For further information about a vulnerability, search its ID in:
https://avd.aquasec.com/
+--------+--------------------+----------------------+----------------------+----------------------+----------+
| ID     | LOCATION           | MITRE CATEGORY       | VULNERABILITY        | DESCRIPTION          | EVIDENCE |
+--------+--------------------+----------------------+----------------------+----------------------+----------+
| KHV002 | 192.168.1.133:6443 | Initial Access //    | K8s Version          | The kubernetes       | v1.23.7  |
|        |                    | Exposed sensitive    | Disclosure           | version could be     |          |
|        |                    | interfaces           |                      | obtained from the    |          |
|        |                    |                      |                      | /version endpoint    |          |
+--------+--------------------+----------------------+----------------------+----------------------+----------+
```

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.