### PR TITLE
Fix: Convert host to str before adding to node_tables (#469)

### DIFF
--- a/kube_hunter/modules/report/plain.py
+++ b/kube_hunter/modules/report/plain.py
@@ -57,7 +57,7 @@ class PlainReporter(BaseReporter):
         services_lock.acquire()
         for service in services:
             if service.event_id not in id_memory:
-                nodes_table.add_row(["Node/Master", service.host])
+                nodes_table.add_row(["Node/Master", str(service.host)])
                 id_memory.add(service.event_id)
         nodes_ret = f"\nNodes\n{nodes_table}\n"
         services_lock.release()


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
This change fixes issue #469, which occurs because `service.host` sometimes is an `IPAddress` instead of a string.
This resulted in a `TypeError: '<' not supported between instances of 'str' and 'IPAddress'` when PrettyTable tries to sort the entries.

The fix was to always convert `service.host` to a string before adding it to the table.

Maybe this is not the right place to fix this issue, as it might not be intended that `service.host` can be an `IPAddress`, but it certainly was the easiest way to get rid of the crash.

## Fixed Issues

Fixes #469 

## "BEFORE" and "AFTER" output

### BEFORE
```
2022-12-09 16:35:11,060 DEBUG kube_hunter.core.events.event_handler Executing <class 'kube_hunter.modules.report.collector.SendFullReport'> with {'previous': None, 'hunter': None}
2022-12-09 16:35:11,061 DEBUG kube_hunter.core.events.event_handler '<' not supported between instances of 'str' and 'IPAddress'
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/kube_hunter/core/events/event_handler.py", line 346, in worker
hook.execute()
File "/usr/local/lib/python3.8/site-packages/kube_hunter/modules/report/collector.py", line 56, in execute
report = config.reporter.get_report(statistics=config.statistics, mapping=config.mapping)
File "/usr/local/lib/python3.8/site-packages/kube_hunter/modules/report/plain.py", line 30, in get_report
output += self.nodes_table()
File "/usr/local/lib/python3.8/site-packages/kube_hunter/modules/report/plain.py", line 63, in nodes_table
nodes_ret = f"\nNodes\n{nodes_table}\n"
File "/usr/local/lib/python3.8/site-packages/prettytable/prettytable.py", line 330, in __str__
return self.get_string()
File "/usr/local/lib/python3.8/site-packages/prettytable/prettytable.py", line 1706, in get_string
rows = self._get_rows(options)
File "/usr/local/lib/python3.8/site-packages/prettytable/prettytable.py", line 1624, in _get_rows
rows.sort(reverse=options["reversesort"], key=options["sort_key"])
TypeError: '<' not supported between instances of 'str' and 'IPAddress'
2022-12-09 16:35:11,063 DEBUG kube_hunter.__main__ Cleaned Queue
```

### AFTER
Crash is gone.

## Contribution checklist
 - [x] I have read the Contributing Guidelines.
 - [x] The commits refer to an active issue in the repository.
 - [ ] I have added automated testing to cover this case.
 
## Notes
I have not added a test.