### PR TITLE
Fixed issue #499 evidence field to display all affected pods and containers

### DIFF
--- a/kube_hunter/modules/hunting/kubelet.py
+++ b/kube_hunter/modules/hunting/kubelet.py
@@ -173,8 +173,8 @@ the whole cluster"""
 
 
 class PrivilegedContainers(Vulnerability, Event):
-    """A Privileged container exist on a node
-    could expose the node/cluster to unwanted root operations"""
+    """A Privileged container exists on a node
+    and could expose the node/cluster to unwanted root operations"""
 
     def __init__(self, containers):
         Vulnerability.__init__(
@@ -185,7 +185,9 @@ class PrivilegedContainers(Vulnerability, Event):
             vid="KHV044",
         )
         self.containers = containers
-        self.evidence = f"pod: {containers[0][0]}, " f"container: {containers[0][1]}, " f"count: {len(containers)}"
+        evidence_list = [f"pod: {pod}, container: {container}" for pod, container in containers]
+        evidence = ", ".join(evidence_list)
+        self.evidence = f"{evidence}, count: {len(containers)}"
 
 
 class ExposedSystemLogs(Vulnerability, Event):


### PR DESCRIPTION
## Description
This is a Fix for the Issue #499 
The evidence field was constructed based on the first container in the list, which is why it only shows information for one pod and one container. I have modified the code to display information for all the affected pods and containers based on the count.

## Fixed Issues
Fixed issue #499 