### PR TITLE
fix:kubectl discovery

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 23.9.1
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]

--- a/tests/discovery/test_kubectl.py
+++ b/tests/discovery/test_kubectl.py
@@ -1,0 +1,13 @@
+# flake8: noqa: E402
+
+from kube_hunter.conf import Config, set_config
+
+set_config(Config())
+
+from kube_hunter.modules.discovery.kubectl import KubectlClientDiscovery
+
+
+def test_kubectl_discovery():
+    discovery = KubectlClientDiscovery(None)
+    version = discovery.get_kubectl_binary_version()
+    assert version is not None


### PR DESCRIPTION
<!---
    Thank you for contributing to Aqua Security.
    Please don't remove the template.
-->

## Description
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.

The kubectl discovery is not functional as the whole command is passed as a single string and thus cannot work with `subprocess.check_output`. This merge request fixes that and simplifies the version parsing as well.

## Contribution Guidelines
Please Read through the [Contribution Guidelines](https://github.com/aquasecurity/kube-hunter/blob/main/CONTRIBUTING.md).

## Fixed Issues

Please mention any issues fixed in the PR by referencing it properly in the commit message.
As per the convention, use appropriate keywords such as `fixes`, `closes`, `resolves` to automatically refer the issue.
Please consult [official github documentation](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) for details.

Fixes #(534)

## "BEFORE" and "AFTER" output

To verify that the change works as desired, please include an output of terminal before and after the changes under headings "BEFORE" and "AFTER".

### BEFORE
Any Terminal Output Before Changes.
`2023-10-14 17:15:45,325 DEBUG Could not find kubectl client`
### AFTER
`2023-10-14 17:35:55,474 DEBUG kube_hunter.modules.discovery.kubectl Found kubectl client: v1.28.2`

## Contribution checklist
 - [X] I have read the Contributing Guidelines.
 - [X] The commits refer to an active issue in the repository.
 - [X] I have added automated testing to cover this case.
 
## Notes
Please mention if you have not checked any of the above boxes.

kubectl is required for the test to pass