### PR TITLE
fixes: resolved severity discrepancy between kube-hunter report and docs

### DIFF
--- a/docs/_kb/KHV002.md
+++ b/docs/_kb/KHV002.md
@@ -2,7 +2,7 @@
 vid: KHV002
 title: Kubernetes version disclosure
 categories: [Information Disclosure]
-severity: low
+severity: high
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV036.md
+++ b/docs/_kb/KHV036.md
@@ -2,7 +2,7 @@
 vid: KHV036
 title: Anonymous Authentication
 categories: [Remote Code Execution]
-severity: critical
+severity: high
 ---
 
 # {{ page.vid }} - {{ page.title }}

--- a/docs/_kb/KHV052.md
+++ b/docs/_kb/KHV052.md
@@ -2,7 +2,7 @@
 vid: KHV052
 title: Exposed Pods
 categories: [Information Disclosure]
-severity: high
+severity: medium
 ---
 
 # {{ page.vid }} - {{ page.title }}


### PR DESCRIPTION
## Description
We have modified the severity for KHV002,KHV036,KHV052 as per the kube-hunter reports as there was a discrepancy between the results displayed by kube-hunter and the avd docs for the mentioned checks

Fixes #(issue) https://github.com/aquasecurity/kube-hunter/issues/549

